### PR TITLE
Adding ASAB Iris

### DIFF
--- a/Site/ASAB Maestro/Descriptors/asab-iris.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-iris.yaml
@@ -1,0 +1,29 @@
+define:
+  type: rc/descriptor
+  name: ASAB Iris
+  tech: asab
+
+descriptor:
+
+  image: docker.teskalabs.com/asab/asab-iris
+
+  volumes:
+    # For a persistency of the configuration
+    - "{{SITE}}/{{INSTANCE_ID}}/conf:/conf:ro"
+
+  restart: on-failure:3
+
+files:
+  - "conf/asab-iris.conf": |
+      [web]
+      listen=8896
+
+    # [smtp] must be filled from general confguration (user)
+    # [slack] must be filled from general confguration (user)
+    # [kafka] will be filled by the remote-control if kafka exists - what about the name of the topic and group_id?
+    # [variables] must be filled from general confguration (user)
+
+api:
+  web:
+    port: 8896
+    upstream: true

--- a/Site/ASAB Maestro/Descriptors/asab-iris.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-iris.yaml
@@ -14,9 +14,7 @@ descriptor:
   restart: on-failure:3
 
 files:
-  - "conf/asab-iris.conf": |
-      [web]
-      listen=8896
+  - "conf/asab-iris.conf": ""
 
     # [smtp] must be filled from general confguration (user)
     # [slack] must be filled from general confguration (user)

--- a/Site/ASAB Maestro/Versions/v23.21.yaml
+++ b/Site/ASAB Maestro/Versions/v23.21.yaml
@@ -12,5 +12,5 @@ versions:
   hello-world: '3.16'  # This is version of Alpine Linux, it must be aligned with asab-governator Dockerfile base image
   elasticsearch: '7.17.9'
   seacat-auth: 'v23.18-beta'
-  asab-iris: latest
+  asab-iris: v23.31-alpha
 

--- a/Site/ASAB Maestro/Versions/v23.21.yaml
+++ b/Site/ASAB Maestro/Versions/v23.21.yaml
@@ -12,4 +12,5 @@ versions:
   hello-world: '3.16'  # This is version of Alpine Linux, it must be aligned with asab-governator Dockerfile base image
   elasticsearch: '7.17.9'
   seacat-auth: 'v23.18-beta'
+  asab-iris: latest
 


### PR DESCRIPTION
 All the configuration of asab iris should be filled in as general configuration (smtp, slack, variables)
I don't know how to sort the services into the applications - there is ASAB Maestro application. There should be some more. Where should live descriptors, version files, and how should the model(s) look?