### PR TITLE
Kibana cache

### DIFF
--- a/Site/ASAB Maestro/Descriptors/kibana.yaml
+++ b/Site/ASAB Maestro/Descriptors/kibana.yaml
@@ -100,7 +100,7 @@ nginx:
     - proxy_set_header X-Request-URI "request_uri"
     - proxy_cache kibana
     - proxy_pass http://upstream-seacat-auth-public/batman/nginx?client_id=kibana
-    - proxy_cache_key $cookie_SeaCatSCI_QBOAFDNWZ52WDP22
+    - proxy_cache_key $cookie_SeaCatSCI_QBOAFDNWZ52WDP22  # This is a cookie paired to the kibana client - it contains hashed client_id - this is based on SeaCat Auth requirements.
     - proxy_cache_lock on
     - proxy_cache_valid 200 10s
     - proxy_ignore_headers Cache-Control Expires Set-Cookie

--- a/Site/ASAB Maestro/Descriptors/kibana.yaml
+++ b/Site/ASAB Maestro/Descriptors/kibana.yaml
@@ -68,6 +68,8 @@ seacat-auth:
       }]
 
 nginx:
+  proxy_caches:
+    kibana: keys_zone=kibana:1m max_size=2m
   https:
     location /kibana:
     - auth_request /_kibana_introspect
@@ -96,9 +98,9 @@ nginx:
     - proxy_method POST
     - proxy_set_body ""
     - proxy_set_header X-Request-URI "request_uri"
-      # proxy_cache batman_responses;
+    - proxy_cache kibana
     - proxy_pass http://upstream-seacat-auth-public/batman/nginx?client_id=kibana
-      # ??? proxy_cache_key $cookie_SeaCatSCI_XXX;
-      # proxy_cache_lock on;
-      # proxy_cache_valid 200 10s;
+    - proxy_cache_key $cookie_SeaCatSCI_QBOAFDNWZ52WDP22
+    - proxy_cache_lock on
+    - proxy_cache_valid 200 10s
     - proxy_ignore_headers Cache-Control Expires Set-Cookie


### PR DESCRIPTION
I thought this would be harder, but you already implemented it :grin: 

```
root@lmio-eliska-1:/opt/site/nginx-1# cat conf.d/proxy_caches.conf 
# GENERATED FILE!

proxy_cache_path /var/cache/nginx/oauth2_introspect_proxy_cache keys_zone=oauth2_introspect:1m max_size=2m;
proxy_cache_path /var/cache/nginx/kibana_proxy_cache keys_zone=kibana:1m max_size=2m;
```

I don't know how to verify it is right - I can open Kibana from UI and when I refresh Kibana I can see request to seacat auth just from time to time, not on every hit. I find it quite good...
