### PR TITLE
Secat auth does not need default config

### DIFF
--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -29,7 +29,7 @@ sherpas:
 
 asab:
   configname: conf/seacatauth.conf
-  config: &config  # specify default configuration of the service
+  config:
     general:
       public_api_base_url: "{{PUBLIC_URL}}/auth/api"
       auth_webui_base_url: "{{PUBLIC_URL}}/auth"
@@ -56,13 +56,6 @@ asab:
       host: <mocked>
 
 asab-config:
-  seacat-auth:
-    __schema__:
-      file: {}
-    config: 
-      file:
-        *config
-      if_not_exists: true
   Tenants:
     __schema__:
       file: 


### PR DESCRIPTION
I forgot to delete the nonsense default config also in seacat auth. And I cannot push to master. And merge without approval. So here it is. 