### PR TITLE
Fix grafana auth - Grafana visits sca through internal nginx server

### DIFF
--- a/Site/ASAB Maestro/Descriptors/grafana.yaml
+++ b/Site/ASAB Maestro/Descriptors/grafana.yaml
@@ -26,8 +26,8 @@ descriptor:
     GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{GRAFANA_CLIENT_SECRET}}"
     GF_AUTH_GENERIC_OAUTH_SCOPES: openid email profile
     GF_AUTH_GENERIC_OAUTH_AUTH_URL: "{{PUBLIC_URL}}/api/openidconnect/authorize"
-    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{PUBLIC_URL}}/api/openidconnect/token"
-    GF_AUTH_GENERIC_OAUTH_API_URL: "{{PUBLIC_URL}}/api/openidconnect/userinfo"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{INTERNAL_URL}}/api/openidconnect/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL: "{{INTERNAL_URL}}/api/openidconnect/userinfo"
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(resources."*"[*], 'authz:superuser') && 'Admin' || contains(resources."*"[*], 'grafana:edit') && 'Editor' || 'Viewer'
 

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -162,5 +162,11 @@ nginx:
       - rewrite ^/auth/api/openidconnect/(.*) /openidconnect/$1 break
       - proxy_pass http://upstream-seacat-auth-public
 
+# this is here for grafana
+  internal:
+    location /api/openidconnect:
+      - rewrite ^/api/openidconnect/(.*) /openidconnect/$1 break
+      - proxy_pass http://upstream-seacat-auth-public
+
 files:
   - "script/"


### PR DESCRIPTION
I've decided this is a temporary solution until we have better service discovery. 

In the meantime, I have an internal URL in the model:
```
params:
  PUBLIC_URL: "https://maestro.logman.io" 
  INTERNAL_URL: "http://lmc01:8890"
```

I guess remote control would be able to create this parameter.

It's not exactly elegant, but dasboards in graphana don't have to wait until we find a nicer solution :) 