### PR TITLE
Seacat Auth update

### DIFF
--- a/Site/ASAB Maestro/Descriptors/kibana.yaml
+++ b/Site/ASAB Maestro/Descriptors/kibana.yaml
@@ -40,11 +40,8 @@ asab-config:
 
 seacat-auth:
   config:
-    "batman:kibana":
+    "batman:elasticsearch":
       kibana_url: "http://{{NODE_ID}}:8890/kibana"
-      url: "http://{{NODE_ID}}:9200" # <- this is not general enough
-      username: elastic
-      password: "{{ELASTIC_PASSWORD}}"
   content:
   - "cl.json": |
       [{

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -31,8 +31,7 @@ asab:
   configname: conf/seacatauth.conf
   config:
     general:
-      public_api_base_url: "{{PUBLIC_URL}}/auth/api"
-      auth_webui_base_url: "{{PUBLIC_URL}}/auth"
+      public_url: "{{PUBLIC_URL}}"
 
     seacatauth:
       private_key: /conf/private-key.pem  # The private file key will be added by ASAB Remote Control / SeaCat Auth tech


### PR DESCRIPTION
Update descriptors to be compatible with [TeskaLabs/seacat-auth/releases/tag/v23.47-alpha5](https://github.com/TeskaLabs/seacat-auth/releases/tag/v23.47-alpha5)

- Seacat Auth public URL config updated 
  - only one public URL is needed, hopefully
  - see TeskaLabs/seacat-auth#330
- Seacat Auth config updated in Kibana descriptor
  - Config section renamed to `batman:elasticsearch`
  - Common ElasticSearch config is loaded from the `elasticsearch` section
  - see TeskaLabs/seacat-auth#326 and TeskaLabs/seacat-auth#333