### PR TITLE
BSQuery and Pyppeteer

### DIFF
--- a/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
@@ -14,7 +14,7 @@ asab:
   configname: conf/asab-pyppeteer.conf
   config:
     seacat_auth:
-      url: http://seacat-auth-1:3081  # TODO!!!
+      url: http://seacat-auth-1:8900  # TODO!!!
     pyppeteer:
       ignore_certificate_errors: 1
       url_white_list: "{{PUBLIC_URL}}"

--- a/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
@@ -1,0 +1,23 @@
+define:
+  type: rc/descriptor
+  name: ASAB Pyppeteer
+
+descriptor:
+  image: docker.teskalabs.com/asab/asab-pyppeteer
+
+  volumes:
+    # For a persistency of the configuration
+    - "{{SITE}}/{{INSTANCE_ID}}/conf:/conf:ro"
+
+
+asab:
+  configname: conf/asab-pyppeteer.conf
+  config:
+    seacat_auth:
+      url: http://seacat-auth-1:3081  # TODO!!!
+    pyppeteer:
+      ignore_certificate_errors: 1
+      url_white_list: "{{PUBLIC_URL}}"
+
+nginx:
+  api: 8895

--- a/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
@@ -13,8 +13,6 @@ descriptor:
 asab:
   configname: conf/asab-pyppeteer.conf
   config:
-    seacat_auth:
-      url: http://seacat-auth-1:8900  # TODO!!!
     pyppeteer:
       ignore_certificate_errors: 1
       url_white_list: "{{PUBLIC_URL}}"

--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -45,7 +45,7 @@ seacat-auth:
         [{
           "_id": "5f362cf58dca6ae0ad997bfc",
           "username": "bs-query",
-          "__password": "{{BSQUERY_PSWD_HASHED}}",
+          "__password": "{{BSQUERY_PSWD_HASHED}}"
         }]
     - "r.json": |
         [{

--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -8,7 +8,7 @@ descriptor:
   volumes:
   - "{{SITE}}/{{INSTANCE_ID}}/conf:/conf:ro"
   - "{{SLOW_STORAGE}}/{{INSTANCE_ID}}:/data/bsquery"
-  # TODO: add jupiter - /data/hdd/jupyter:/data/jupyter
+  # TODO: add jupyter - /data/hdd/jupyter:/data/jupyter
 
 asab:
   configname: conf/bs-query.conf
@@ -48,7 +48,8 @@ seacat-auth:
         [{
           "_id": "*/impersonator",
           "resources": [
-            "authz:impersonate"
+            "authz:impersonate",
+            "seacat:access"
           ]
         }]
     - "ct.json": |
@@ -72,49 +73,40 @@ nginx:
   https:
     location /api/bs-query/export-download:
       - rewrite /api/bs-query/(.*) /$1 break
-      - proxy_pass http://{{NODE_ID}}:8790  # TODO!?
+      - proxy_pass http://{{NODE_ID}}:8790
 
 
-# asab-config:
-#   bs-query:
-#     __schema__:
-#       file:
-#         {
-#           "title": "bs-query",
-#           "type": "object",
-#           "properties": {
-#             "download": {
-#               "title": "Downloads Configuration",
-#               "type": "object",
-#               "properties": {
-#                 "expiration": {
-#                   "type": "string",
-#                   "title": "Link Expiration Time",
-#                   "description": "Configure how fast a download link expires (in seconds)."
-#                 }
-#               }
-#             },
-#             "xlsx": {
-#               "title": "Files Configuration",
-#               "type": "object",
-#                "properties": {
-#                   "limit": {
-#                     "type": "string",
-#                     "title": "File Size Limit",
-#                     "description": "Configure the maximum size of xlsx files. Default is 50 000 rows."
-#                   }
-#                 }
-#             },
-#             "target:email": {
-#               "title": "Emails Configuration",
-#               "type": "object",
-#               "properties": {
-#                 "file_size_limit": {
-#                   "type": "string",
-#                   "title": "Attachment Size Limit"
-#                   "description": "Configure the maximum size of email attachments. Default is 50 Mb.",
-#                 }
-#               }
-#             }
-#           }
-#         }
+asab-config:
+  bs-query:
+    __schema__:
+      file:
+        {
+          "title": "bs-query",
+          "type": "object",
+          "properties": {
+            "xlsx": {
+              "title": "Files Configuration",
+              "type": "object",
+               "properties": {
+                  "limit": {
+                    "type": "string",
+                    "title": "File Size Limit",
+                    "description": "Configure the maximum size of xlsx files. Default is 50 000 rows."
+                  }
+                }
+            },
+            "target:email": {
+              "title": "Emails Configuration",
+              "type": "object",
+              "properties": {
+                "file_size_limit": {
+                  "type": "string",
+                  "title": "Attachment Size Limit",
+                  "description": "Configure the maximum size of email attachments. Default is 50 Mb."
+                }
+              }
+            }
+          }
+        }
+    config.json:
+      file: {}  # TODO: add default values

--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -25,10 +25,6 @@ asab:
     # TODO: remove after bs-query is ready to read the config section
       url: "{{ ELASTIC_HOSTS_AUTHORIZED|join(' ') }}"
 
-    auth:
-      multitenancy: "yes"
-      public_keys_url: http://seacat-auth-1:3081/openidconnect/public_keys  # TODO!!!
-
     pyppeteer:  # TODO !!!
       username: bs-query
       password: "{{BSQUERY_PASSWORD}}"

--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -2,6 +2,9 @@ define:
   type: rc/descriptor
   name: BS Query
 
+secrets:
+  BSQUERY_PSWD: {}
+
 descriptor:
   image: docker.teskalabs.com/bs-query
 
@@ -27,9 +30,9 @@ asab:
       public_keys_url: http://seacat-auth-1:3081/openidconnect/public_keys  # TODO!!!
 
     pyppeteer:  # TODO !!!
-      url: http://asab-pyppeteer-1:8895
       username: bs-query
-      password: bs-query
+      password: "{{BSQUERY_PSWD}}"
+      url: http://asab-pyppeteer-1:8895  # TODO !! service discovery
 
 
 seacat-auth:
@@ -37,12 +40,12 @@ seacat-auth:
     "seacatauth:credentials:m2m:machine":
       mongodb_uri: "{{MONGO_URI}}"
       mongodb_database: auth
-  content:
+  content: # BSQUERY_PSWD_HASHED created by bsquery tech
     - "mc.json": |
         [{
           "_id": "5f362cf58dca6ae0ad997bfc",
           "username": "bs-query",
-          "__password": "$2b$12$mKgt17p7sSjHVQO3O00bNO3L3iRcT5MSx06.tQRY7nXL.DtA8rkaq",
+          "__password": "{{BSQUERY_PSWD_HASHED}}",
         }]
     - "r.json": |
         [{

--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -3,7 +3,7 @@ define:
   name: BS Query
 
 secrets:
-  BSQUERY_PSWD: {}
+  BSQUERY_PASSWORD: {}
 
 descriptor:
   image: docker.teskalabs.com/bs-query
@@ -31,7 +31,7 @@ asab:
 
     pyppeteer:  # TODO !!!
       username: bs-query
-      password: "{{BSQUERY_PSWD}}"
+      password: "{{BSQUERY_PASSWORD}}"
       url: http://asab-pyppeteer-1:8895  # TODO !! service discovery
 
 
@@ -40,12 +40,12 @@ seacat-auth:
     "seacatauth:credentials:m2m:machine":
       mongodb_uri: "{{MONGO_URI}}"
       mongodb_database: auth
-  content: # BSQUERY_PSWD_HASHED created by bsquery tech
+  content: # BSQUERY_PASSWORD_HASHED created by bsquery tech
     - "mc.json": |
         [{
           "_id": "5f362cf58dca6ae0ad997bfc",
           "username": "bs-query",
-          "__password": "{{BSQUERY_PSWD_HASHED}}"
+          "__password": "{{BSQUERY_PASSWORD_HASHED}}"
         }]
     - "r.json": |
         [{

--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -22,51 +22,99 @@ asab:
     # TODO: remove after bs-query is ready to read the config section
       url: "{{ ELASTIC_HOSTS_AUTHORIZED|join(' ') }}"
 
-    # TODO: needs to be here, but currently is in model
-    # auth:
-    #   multitenancy: "yes"
-    #   public_keys_url: http://lmc01:3081/openidconnect/public_keys
+    auth:
+      multitenancy: "yes"
+      public_keys_url: http://seacat-auth-1:3081/openidconnect/public_keys  # TODO!!!
 
-asab-config:
-  bs-query:
-    __schema__:
-      file:
-        {
-          "title": "bs-query",
-          "type": "object",
-          "properties": {
-            "download": {
-              "title": "Downloads Configuration",
-              "type": "object",
-              "properties": {
-                "expiration": {
-                  "type": "string",
-                  "title": "Link Expiration Time",
-                  "description": "Configure how fast a download link expires (in seconds)."
-                }
-              }
-            },
-            "xlsx": {
-              "title": "Files Configuration",
-              "type": "object",
-               "properties": {
-                  "limit": {
-                    "type": "string",
-                    "title": "File Size Limit",
-                    "description": "Configure the maximum size of xlsx files. Default is 50 000 rows."
-                  }
-                }
-            },
-            "target:email": {
-              "title": "Emails Configuration",
-              "type": "object",
-              "properties": {
-                "file_size_limit": {
-                  "type": "string",
-                  "title": "Attachment Size Limit"
-                  "description": "Configure the maximum size of email attachments. Default is 50 Mb.",
-                }
-              }
-            }
-          }
-        }
+    pyppeteer:  # TODO !!!
+      url: http://asab-pyppeteer-1:8895
+      username: bs-query
+      password: bs-query
+
+
+seacat-auth:
+  config:
+    "seacatauth:credentials:m2m:machine":
+      mongodb_uri: "{{MONGO_URI}}"
+      mongodb_database: auth
+  content:
+    - "mc.json": |
+        [{
+          "_id": "5f362cf58dca6ae0ad997bfc",
+          "username": "bs-query",
+          "__password": "$2b$12$mKgt17p7sSjHVQO3O00bNO3L3iRcT5MSx06.tQRY7nXL.DtA8rkaq",
+        }]
+    - "r.json": |
+        [{
+          "_id": "*/impersonator",
+          "resources": [
+            "authz:impersonate"
+          ]
+        }]
+    - "ct.json": |
+        [{
+          "_id": "m2m:machine:5f362cf58dca6ae0ad997bfc system",
+          "c": "m2m:machine:5f362cf58dca6ae0ad997bfc",
+          "t": "system"
+        }]
+    - "cr.json": |
+        [{
+          "_id": "m2m:machine:5f362cf58dca6ae0ad997bfc */impersonator",
+          "c": "m2m:machine:5f362cf58dca6ae0ad997bfc",
+          "r": "*/impersonator"
+        }]
+
+
+nginx:
+  api: 8790
+
+  # This is here for download endpoint with non-oauth authorization
+  https:
+    location /api/bs-query/export-download:
+      - rewrite /api/bs-query/(.*) /$1 break
+      - proxy_pass http://{{NODE_ID}}:8790  # TODO!?
+
+
+# asab-config:
+#   bs-query:
+#     __schema__:
+#       file:
+#         {
+#           "title": "bs-query",
+#           "type": "object",
+#           "properties": {
+#             "download": {
+#               "title": "Downloads Configuration",
+#               "type": "object",
+#               "properties": {
+#                 "expiration": {
+#                   "type": "string",
+#                   "title": "Link Expiration Time",
+#                   "description": "Configure how fast a download link expires (in seconds)."
+#                 }
+#               }
+#             },
+#             "xlsx": {
+#               "title": "Files Configuration",
+#               "type": "object",
+#                "properties": {
+#                   "limit": {
+#                     "type": "string",
+#                     "title": "File Size Limit",
+#                     "description": "Configure the maximum size of xlsx files. Default is 50 000 rows."
+#                   }
+#                 }
+#             },
+#             "target:email": {
+#               "title": "Emails Configuration",
+#               "type": "object",
+#               "properties": {
+#                 "file_size_limit": {
+#                   "type": "string",
+#                   "title": "Attachment Size Limit"
+#                   "description": "Configure the maximum size of email attachments. Default is 50 Mb.",
+#                 }
+#               }
+#             }
+#           }
+#         }

--- a/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
+++ b/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
@@ -29,7 +29,7 @@ function load_data() {
  */
 function transform_collection(collectionName, data) {
 	data.forEach((record) => {
-		if (collectionName === "c") {
+		if (collectionName === "c" | collectionName === "mc") {
 			record["_id"] = ObjectId(record._id)  // IDs of users are stored as ObjectId
 		}
 		record["_c"] = new Date()

--- a/Site/ASAB Maestro/Versions/v24.01.yaml
+++ b/Site/ASAB Maestro/Versions/v24.01.yaml
@@ -7,7 +7,7 @@ versions:
   zookeeper: '3.9'
   asab-remote-control: latest
   asab-governator: stable
-  asab-library: v23.15-beta
+  asab-library: latest
   asab-config: v23.45
   seacat-auth: v23.47-alpha5
   asab-iris: v23.31-alpha

--- a/Site/ASAB Maestro/Versions/v24.01.yaml
+++ b/Site/ASAB Maestro/Versions/v24.01.yaml
@@ -20,7 +20,8 @@ versions:
   grafana: '10.0.8'
   kafdrop: '4.0.0'
   kafka: '7.5.1'
-  bs-query: v24.01-alpha7
+  bs-query: v24.01-alpha13
+  asab-pyppeteer: v23.47-beta
 
   webapp seacat-auth: v23.29-beta
   webapp influxdb: v2.7.1

--- a/Site/ASAB Maestro/Versions/v24.01.yaml
+++ b/Site/ASAB Maestro/Versions/v24.01.yaml
@@ -9,7 +9,7 @@ versions:
   asab-governator: stable
   asab-library: latest
   asab-config: v23.45
-  seacat-auth: v23.47-alpha5
+  seacat-auth: latest
   asab-iris: v23.50
   nginx: '1.25.2'
   elasticsearch: '7.17.12'

--- a/Site/ASAB Maestro/Versions/v24.01.yaml
+++ b/Site/ASAB Maestro/Versions/v24.01.yaml
@@ -1,0 +1,26 @@
+define:
+  type: rc/version
+  product: ASAB Maestro
+  version: v23.47
+
+versions:
+  zookeeper: '3.9'
+  asab-remote-control: latest
+  asab-governator: stable
+  asab-library: v23.15-beta
+  asab-config: v23.45
+  seacat-auth: v23.47-alpha5
+  asab-iris: v23.31-alpha
+  nginx: '1.25.2'
+  elasticsearch: '7.17.12'
+  mongo: '7.0.1'
+  kibana: '7.17.2'
+  influxdb: '2.7.1'
+  telegraf: '1.28.2'
+  grafana: '10.0.8'
+  kafdrop: '4.0.0'
+  kafka: '7.5.1'
+  bs-query: v23.48-alpha
+
+  webapp seacat-auth: v23.29-beta
+  webapp influxdb: v2.7.1

--- a/Site/ASAB Maestro/Versions/v24.01.yaml
+++ b/Site/ASAB Maestro/Versions/v24.01.yaml
@@ -10,7 +10,7 @@ versions:
   asab-library: latest
   asab-config: v23.45
   seacat-auth: v23.47-alpha5
-  asab-iris: v23.31-alpha
+  asab-iris: v23.50
   nginx: '1.25.2'
   elasticsearch: '7.17.12'
   mongo: '7.0.1'
@@ -20,7 +20,7 @@ versions:
   grafana: '10.0.8'
   kafdrop: '4.0.0'
   kafka: '7.5.1'
-  bs-query: v23.48-alpha
+  bs-query: v24.01-alpha7
 
   webapp seacat-auth: v23.29-beta
   webapp influxdb: v2.7.1


### PR DESCRIPTION
TODO:

- [x] service discovery: right now, I configured to the services: `http://seacat-auth-1:8900` or `http://seacat-auth-1:3081` and it works, but I would like to see something more clever
TODO: Implement Discovery session where needed

- [x] I gave aaaaall that is needed for SCA into the bsquery descriptor - Robin told me, that pyppeteer is not the impersonator, but bs-query is, so I think it belongs there. I didn't manage to make the password secret, yet, because it must be hashed before saved into mongodb and this must be done within bs-query tech which does not exists, yet. I will do that, it is not difficult, but it is not nice. I would like to see this impersonator thing somehow simplified. Instead, it is getting, slightly, but still more complicated.