### PR TITLE
Grafana - oauth without grafana tech

### DIFF
--- a/Site/ASAB Maestro/Descriptors/grafana.yaml
+++ b/Site/ASAB Maestro/Descriptors/grafana.yaml
@@ -5,6 +5,7 @@ define:
 
 secrets:
   GRAFANA_PASSWORD: {}
+  GRAFANA_CLIENT_SECRET: {}
 
 descriptor:
   image: grafana/grafana
@@ -29,8 +30,8 @@ descriptor:
     GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{GRAFANA_CLIENT_SECRET}}"
     GF_AUTH_GENERIC_OAUTH_SCOPES: openid email profile
     GF_AUTH_GENERIC_OAUTH_AUTH_URL: "{{PUBLIC_URL}}/api/openidconnect/authorize"
-    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{INTERNAL_URL}}/api/openidconnect/token"
-    GF_AUTH_GENERIC_OAUTH_API_URL: "{{INTERNAL_URL}}/api/openidconnect/userinfo"
+    GF_AUTH_GENERIC_OAUTH_TOKEN_URL: "{{SEACAT_AUTH_PUBLIC}}/openidconnect/token"
+    GF_AUTH_GENERIC_OAUTH_API_URL: "{{SEACAT_AUTH_PUBLIC}}/openidconnect/userinfo"
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(resources."*"[*], 'authz:superuser') && 'Admin' || contains(resources."*"[*], 'grafana:edit') && 'Editor' || contains(resources."*"[*], 'grafana:access') && 'Viewer'
 

--- a/Site/ASAB Maestro/Descriptors/grafana.yaml
+++ b/Site/ASAB Maestro/Descriptors/grafana.yaml
@@ -3,6 +3,9 @@ define:
   name: Grafana
   url: https://github.com/grafana/grafana
 
+secrets:
+  GRAFANA_PASSWORD: {}
+
 descriptor:
   image: grafana/grafana
 

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -4,6 +4,10 @@ define:
   name: Seacat Auth
   url: https://github.com/TeskaLabs/seacat-auth
 
+params:
+  SEACAT_AUTH_PRIVATE: "http://seacat-auth:8900"
+  SEACAT_AUTH_PUBLIC: "http://seacat-auth:3081"
+
 descriptor:
   image: teskalabs/seacat-auth
   
@@ -161,11 +165,6 @@ nginx:
       - rewrite ^/auth/api/openidconnect/(.*) /openidconnect/$1 break
       - proxy_pass http://upstream-seacat-auth-public
 
-# this is here for grafana
-  internal:
-    location /api/openidconnect:
-      - rewrite ^/api/openidconnect/(.*) /openidconnect/$1 break
-      - proxy_pass http://upstream-seacat-auth-public
 
 files:
   - "script/"

--- a/Site/ASAB Maestro/Files/seacat-auth/script/to_upload/seacat-auth/c.json
+++ b/Site/ASAB Maestro/Files/seacat-auth/script/to_upload/seacat-auth/c.json
@@ -1,6 +1,6 @@
 [{
 	"_id": "58acb7acccce58ffa8b953b1",
-	"email": "",
+	"email": "admin@mock.com",
 	"username": "admin",
 	"__password": "$2b$12$gV5pNXpjT70qxAqJ.xfEGObiaIa3znrpML4R55EOsM1RvTyGxNbi.",
 	"enforce_factors": []


### PR DESCRIPTION
I used
- secrets in grafana tech,
- params in seacat-auth tech

I removed seacat auth internal location, which is good.

Grafana needs to know an e-mail of the user to authorize them. However, admin does not have an e-mail by default. So I added some nonsense e-mail there and Grafana is happy.

Grafana needs to access public port of seacat auth, because the endpoint is not available on the private port, but it should be, right? @byewokko 
