### PR TITLE
Kafdrop: fix typo

### DIFF
--- a/Site/ASAB Maestro/Descriptors/kafdrop.yaml
+++ b/Site/ASAB Maestro/Descriptors/kafdrop.yaml
@@ -25,8 +25,8 @@ nginx:
       - proxy_set_header X-Real-IP $remote_addr
       - proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
       - proxy_set_header X-Forwarded-Proto $scheme
-      - prror_page 403 /auth
-      - prror_page 401 /auth/api/openidconnect/authorize?response_type=code&scope=cookie&client_id=kafdrop&redirect_uri={{PUBLIC_URL}}$request_uri
+      - error_page 403 /auth
+      - error_page 401 /auth/api/openidconnect/authorize?response_type=code&scope=cookie&client_id=kafdrop&redirect_uri={{PUBLIC_URL}}$request_uri
 
     location /kafdrop_cookie_introspect:
       - internal


### PR DESCRIPTION
tohle typo killne nginx a dologmanovali jsme...
takže prosím rychlý approve

a bohužel to nefunguje ani když opravím typo