### PR TITLE
Add hybrid locations

### DIFF
--- a/Site/ASAB Maestro/Files/nginx/conf.d/server_https.conf
+++ b/Site/ASAB Maestro/Files/nginx/conf.d/server_https.conf
@@ -28,4 +28,5 @@ server {
 	gzip_disable "MSIE [1-6]\.";
 
 	include /etc/nginx/conf.d/server_https.d/*.conf;
+	include /etc/nginx/shared/server_https.d/*.conf;
 }


### PR DESCRIPTION
@Plesoun This is the "lidová tvořivost".

This oneliner allows adding locations to `/data/hdd/nginx/shared/server_https.d/` manually to allow hybrid installation.
I've just installed lmio-alerts using this feature (even though lmio-alerts service is a great adept for maestro)