### PR TITLE
NGINX IPv6 support

### DIFF
--- a/Site/ASAB Maestro/Descriptors/nginx.yaml
+++ b/Site/ASAB Maestro/Descriptors/nginx.yaml
@@ -34,6 +34,12 @@ descriptor:
 files:
   - "conf.d/"
   - "sherpa/"
+  - "conf.d/server_https.d/01-listen.conf": |
+      listen 443 ssl default_server;
+      # TODO listen [::]:443 ssl default_server;
+  - "conf.d/server_http.d/01-listen.conf": |
+      listen 80 default_server deferred;
+      # TODO listen [::]:80 default_server deferred;
 
 sherpas:
   webapp-dist:

--- a/Site/ASAB Maestro/Descriptors/nginx.yaml
+++ b/Site/ASAB Maestro/Descriptors/nginx.yaml
@@ -30,16 +30,18 @@ descriptor:
     retries: 5
     start_period: 10s
 
-
 files:
   - "conf.d/"
   - "sherpa/"
+
+  # This controls where NGINX listens
   - "conf.d/server_https.d/01-listen.conf": |
       listen 443 ssl default_server;
-      # TODO listen [::]:443 ssl default_server;
+      {% if NGINX_LISTEN_IPV6 %}listen [::]:443 ssl default_server;{% endif %}
+  
   - "conf.d/server_http.d/01-listen.conf": |
       listen 80 default_server deferred;
-      # TODO listen [::]:80 default_server deferred;
+      {% if NGINX_LISTEN_IPV6 %}listen [::]:80 default_server deferred;{% endif %}
 
 sherpas:
   webapp-dist:

--- a/Site/ASAB Maestro/Files/nginx/conf.d/server_http.conf
+++ b/Site/ASAB Maestro/Files/nginx/conf.d/server_http.conf
@@ -4,9 +4,6 @@
 # IMPORTANT: There is no API provided by this server.
 
 server {
-	listen 80 default_server deferred;
-	# TODO: listen [::]:80 default_server deferred;
-
 	server_name _;
 	server_tokens off;
 

--- a/Site/ASAB Maestro/Files/nginx/conf.d/server_https.conf
+++ b/Site/ASAB Maestro/Files/nginx/conf.d/server_https.conf
@@ -1,8 +1,5 @@
 # This is a main server on HTTPS
 server {
-	listen 443 ssl default_server;
-	# TODO: listen [::]:443 ssl default_server;
-
 	http2 on;
 
 	server_name _;


### PR DESCRIPTION
This is a preparation for the IPv6 support in NGINX.
It moves "listen" directives to descriptor YAML, so that Jinja2 templating can be applied.

TODO: In NGINX tech, `NGINX_LISTEN_IPV6` Jinja2 variable should be set to "1", if there is IPv6 protocol enabled (or configuration explicitly want that.

--- or in model ---

```
define:
  type: rc/model
...
params:
  NGINX_LISTEN_IPV6: true
```