### PR TITLE
Fix limited request header to make admin role possible

### DIFF
--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -165,6 +165,7 @@ nginx:
       - rewrite ^/auth/api/openidconnect/(.*) /openidconnect/$1 break
       - proxy_pass http://upstream-seacat-auth-public
 
+    # Headers containing user info (roles and resources) are so huge the default size must be extended
     server:
       - proxy_buffer_size         128k
       - proxy_buffers           4 256k

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -165,6 +165,11 @@ nginx:
       - rewrite ^/auth/api/openidconnect/(.*) /openidconnect/$1 break
       - proxy_pass http://upstream-seacat-auth-public
 
+    server:
+      - proxy_buffer_size         128k
+      - proxy_buffers           4 256k
+      - proxy_busy_buffers_size   256k
+
 
 files:
   - "script/"


### PR DESCRIPTION
Users with "admin" role in LMIO could not get through nginx (with 500) and Robin found that the list of the resources is so big for admins that it does not fit into headers.

I did this hotfix in app.logman.io but now we need to find some proper place for this bit.

```
2024/03/05 16:31:11 [error] 36#36: *801 upstream sent too big header while reading response header from upstream, client: 109.81.174.194, server: _, request: "GET /api/seacat-auth/credentials?p=1&i=27 HTTP/2.0", subrequest: "/_oauth2_introspect", upstream: "http://10.17.211.99:8900/nginx/introspect/openidconnect", host: "app.logman.io", referrer: "https://app.logman.io/"
```