### PR TITLE
Fix tools redirects

### DIFF
--- a/Site/ASAB Maestro/Descriptors/jupyter.yaml
+++ b/Site/ASAB Maestro/Descriptors/jupyter.yaml
@@ -41,7 +41,7 @@ asab-config:
               "Tool": {
                   "image": "media/tools/jupyter.svg",
                   "name": "Jupyter Notebook",
-                  "url": "{{PUBLIC_URL}}/jupyter"
+                  "url": "/jupyter"
               }
           }
 

--- a/Site/ASAB Maestro/Descriptors/kafdrop.yaml
+++ b/Site/ASAB Maestro/Descriptors/kafdrop.yaml
@@ -48,7 +48,7 @@ asab-config:
               "Tool": {
                   "image": "media/tools/kafka.svg",
                   "name": "Kafdrop",
-                  "url": "{{PUBLIC_URL}}/kafdrop"
+                  "url": "/kafdrop"
               },
               "Authorization": {
                   "tenants": "system"

--- a/Site/ASAB Maestro/Descriptors/kibana.yaml
+++ b/Site/ASAB Maestro/Descriptors/kibana.yaml
@@ -55,7 +55,7 @@ seacat-auth:
         ],
         "redirect_uri_validation_method": "prefix_match",
         "redirect_uris": [
-          "{{PUBLIC_URL}}/kibana"
+          "/kibana"
         ],
         "response_types": [
           "code"

--- a/Site/ASAB Maestro/Descriptors/zoonavigator.yaml
+++ b/Site/ASAB Maestro/Descriptors/zoonavigator.yaml
@@ -24,7 +24,7 @@ asab-config:
               "Tool": {
                   "image": "media/tools/zookeeper.svg",
                   "name": "Zoonavigator",
-                  "url": "{{PUBLIC_URL}}/zoonavigator"
+                  "url": "/zoonavigator"
               },
               "Authorization": {
                   "tenants": "system"


### PR DESCRIPTION
Seacat-auth mongo content sherpa does insert only - it creates new document only if it does not exists, yet. 
However, in case of clients, this is not very favorable.
If public url changes (it is "localhost" in the very beggining and it needs to be changes by the user in the model) the PUBLIC_URL in the client stayes the same. And redirect does not work.
So, I suggest to make the clients "managed" and do "upsert" - insert and update so the clients are changed whenever PUBLIC_URL changes. However, this is a bit more interactions of the script with mongodb directly. 

Clients should be tagged "managed" in the secat auth also, so they are either not editable fromt he UI at all or the user is at least adviced that their changes will be rewritten by maestro.

OR

Seacat auth will learn to work with relative URLs, but I don't know how much is that possible.