### PR TITLE
Fix restart policy: we want containers to survive reboot test

### DIFF
--- a/Site/ASAB Maestro/Descriptors/__commons__.yaml
+++ b/Site/ASAB Maestro/Descriptors/__commons__.yaml
@@ -25,7 +25,7 @@ descriptor:
       max-size: 10m
 
   # We do restarts
-  restart: unless-stopped
+  restart: always
 
 # Common descriptor for sherpas
 sherpa:


### PR DESCRIPTION
the same must be in lmio-common library as we still have two __commons__ descriptors :(