### PR TITLE
Increase proxy buffer size in introspection locations only

### DIFF
--- a/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
+++ b/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
@@ -71,6 +71,11 @@ nginx:
     - proxy_cache_valid 200 10s
     - proxy_ignore_headers Cache-Control Expires Set-Cookie
 
+    # Increase buffer size to fit large Authorization headers
+    - proxy_buffer_size         32k
+    - proxy_buffers           4 64k
+    - proxy_busy_buffers_size   64k
+
 seacat-auth:
   content:
   - "cl.json": |

--- a/Site/ASAB Maestro/Descriptors/jupyter.yaml
+++ b/Site/ASAB Maestro/Descriptors/jupyter.yaml
@@ -82,6 +82,11 @@ nginx:
       - proxy_cache_valid 200 10s
       - proxy_ignore_headers Cache-Control Expires Set-Cookie
 
+      # Increase buffer size to fit large Authorization headers
+      - proxy_buffer_size         32k
+      - proxy_buffers           4 64k
+      - proxy_busy_buffers_size   64k
+
 seacat-auth:
   content:
   - "cl.json": |

--- a/Site/ASAB Maestro/Descriptors/kafdrop.yaml
+++ b/Site/ASAB Maestro/Descriptors/kafdrop.yaml
@@ -40,6 +40,11 @@ nginx:
       - proxy_cache_valid 200 10s
       - proxy_ignore_headers Cache-Control Expires Set-Cookie
 
+      # Increase buffer size to fit large Authorization headers
+      - proxy_buffer_size         32k
+      - proxy_buffers           4 64k
+      - proxy_busy_buffers_size   64k
+
 asab-config:
   Tools:
      Kafdrop: 

--- a/Site/ASAB Maestro/Descriptors/kibana.yaml
+++ b/Site/ASAB Maestro/Descriptors/kibana.yaml
@@ -115,3 +115,8 @@ nginx:
     - proxy_cache_lock on
     - proxy_cache_valid 200 10s
     - proxy_ignore_headers Cache-Control Expires Set-Cookie
+
+    # Increase buffer size to fit large Authorization headers
+    - proxy_buffer_size         32k
+    - proxy_buffers           4 64k
+    - proxy_busy_buffers_size   64k

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -148,6 +148,11 @@ nginx:
       - proxy_cache_lock on
       - proxy_cache_valid 200 30s
 
+      # Increase buffer size to fit large Authorization headers
+      - proxy_buffer_size         32k
+      - proxy_buffers           4 64k
+      - proxy_busy_buffers_size   64k
+
     location /api/openidconnect:
       - rewrite ^/api/openidconnect/(.*) /openidconnect/$1 break
       - proxy_pass http://upstream-seacat-auth-public
@@ -164,12 +169,6 @@ nginx:
     location /auth/api/openidconnect:
       - rewrite ^/auth/api/openidconnect/(.*) /openidconnect/$1 break
       - proxy_pass http://upstream-seacat-auth-public
-
-    # Headers containing user info (roles and resources) are so huge the default size must be extended
-    server:
-      - proxy_buffer_size         128k
-      - proxy_buffers           4 256k
-      - proxy_busy_buffers_size   256k
 
 
 files:

--- a/Site/ASAB Maestro/Descriptors/zoonavigator.yaml
+++ b/Site/ASAB Maestro/Descriptors/zoonavigator.yaml
@@ -63,6 +63,11 @@ nginx:
       - proxy_cache_valid 200 10s
       - proxy_ignore_headers Cache-Control Expires Set-Cookie
 
+      # Increase buffer size to fit large Authorization headers
+      - proxy_buffer_size         32k
+      - proxy_buffers           4 64k
+      - proxy_busy_buffers_size   64k
+
 seacat-auth:
   content:
   - "cl.json": |


### PR DESCRIPTION
Large proxy buffers are only needed for introspection responses, not in the whole server block.