### PR TITLE
Update Seacat Auth config

### DIFF
--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -23,10 +23,6 @@ asab:
 
 
 seacat-auth:
-  config:
-    "seacatauth:credentials:m2m:machine":
-      mongodb_uri: "{{MONGO_URI}}"
-      mongodb_database: auth
   content: # BSQUERY_PASSWORD_HASHED created by bsquery tech
     - "mc.json": |
         [{

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -42,15 +42,13 @@ asab:
 
     asab:storage:
       type: mongodb
-      mongodb_uri: "{{MONGO_URI}}"
-      mongodb_database: auth
       aes_key: null  # Will be filled by ASAB Remote Control
 
     seacatauth:credentials:mongodb:default:
-      mongodb_uri: "{{MONGO_URI}}"
-      mongodb_database: auth
       tenants: yes
       register: no
+
+    seacatauth:credentials:m2m:machine: {}
 
     seacatauth:communication:email:smtp:
       # By default, SMTP configuration is mocked - e-mails are printed into log of seacat-auth


### PR DESCRIPTION
- Simplify mongodb config (https://github.com/TeskaLabs/asab/pull/553)
- Move M2M credentials from bsquery to seacat auth

Compatible with Seacat Auth [v24.06-alpha10](https://github.com/TeskaLabs/seacat-auth/releases/tag/v24.06-alpha10) and later