### PR TITLE
Zookeeper max clients - Increase from 60 to 600

### DIFF
--- a/Site/ASAB Maestro/Files/zookeeper/confro/zoo.cfg
+++ b/Site/ASAB Maestro/Files/zookeeper/confro/zoo.cfg
@@ -17,7 +17,7 @@ syncLimit=5
 
 # The maximum number of client connections.
 # increase this if you need to handle more clients
-maxClientCnxns=60
+maxClientCnxns=600
 
 # See https://zookeeper.apache.org/doc/r3.8.0/zookeeperReconfig.html#sc_reconfig_standaloneEnabled
 standaloneEnabled=false


### PR DESCRIPTION
... addressing this problem:

```
2024-03-25 10:56:37,046 [myid:] - WARN  [NIOServerCxnFactory.AcceptThread:/0.0.0.0:2181:o.a.z.s.RateLogger@87] - Message:Error accepting new connection: Too many connections from /127.0.0.1 - max is 60 Value:null
2024-03-25 10:56:51,938 [myid:] - WARN  [NIOServerCxnFactory.AcceptThread:/0.0.0.0:2181:o.a.z.s.RateLogger@57] - Message: Error accepting new connection: Too many connections from /127.0.0.1 - max is 60
```

*WARNING:* Since Zookeeper works with configurations very weirdly, this likely needs to be changes in governator.bootstrap.

Also - we now a practical case for a need of changing Zookeeper configuration during a cluster life time - this is currently impossible in ASAB Maestro