### PR TITLE
Add telegraf tech

### DIFF
--- a/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
+++ b/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
@@ -105,3 +105,12 @@ seacat-auth:
         "cookie_entry_uri": "{{PUBLIC_URL}}/api/cookie-entry",
         "client_uri": "{{PUBLIC_URL}}/api/elasticsearch"
       }]
+
+telegraf: |
+  [[inputs.elasticsearch]]
+    servers = {{ELASTIC_HOSTS_AUTHORIZED}}
+    http_timeout = "9s"
+    local = false
+    cluster_health = true
+    cluster_health_level = "indices"
+    cluster_stats = true

--- a/Site/ASAB Maestro/Descriptors/telegraf.yaml
+++ b/Site/ASAB Maestro/Descriptors/telegraf.yaml
@@ -32,8 +32,6 @@ descriptor:
     - /proc:/hostfs/proc:ro
     - /sys:/hostfs/sys:ro
     - /run:/hostfs/run:ro
-    # For a communication with a docker
-    - /var/run/docker.sock:/var/run/docker.sock
 
 files:
   - "telegraf.d/telegraf.conf": |

--- a/Site/ASAB Maestro/Descriptors/telegraf.yaml
+++ b/Site/ASAB Maestro/Descriptors/telegraf.yaml
@@ -22,7 +22,7 @@ descriptor:
 
   volumes:
     # For a persistency of the configuration
-    - "{{SITE}}/{{INSTANCE_ID}}/conf:/etc/telegraf:ro"
+    - "{{SITE}}/{{INSTANCE_ID}}/telegraf.d:/etc/telegraf/telegraf.d:ro"
     # Logs
     - "{{SLOW_STORAGE}}/{{INSTANCE_ID}}/logs:/var/log/telegraf"
     # Mounting importang bits from the host
@@ -36,7 +36,7 @@ descriptor:
     - /var/run/docker.sock:/var/run/docker.sock
 
 files:
-  - "conf/telegraf.conf": |
+  - "telegraf.d/telegraf.conf": |
       [global_tags]
       
       [agent]

--- a/Site/ASAB Maestro/Descriptors/telegraf.yaml
+++ b/Site/ASAB Maestro/Descriptors/telegraf.yaml
@@ -9,9 +9,6 @@ descriptor:
   # The gid=0 is to enable communication with a Docker/Podman for metrics extraction
   user: "10002:0"
 
-  volumes:
-    - "{{SLOW_STORAGE}}/{{INSTANCE_ID}}/data:/var/lib/influxdb2"
-
   environment:
     HOST_MOUNT_PREFIX: /hostfs
     HOST_PROC: /hostfs/proc
@@ -32,6 +29,8 @@ descriptor:
     - /proc:/hostfs/proc:ro
     - /sys:/hostfs/sys:ro
     - /run:/hostfs/run:ro
+    # For a communication with a docker
+    - /var/run/docker.sock:/var/run/docker.sock
 
 files:
   - "telegraf.d/telegraf.conf": |


### PR DESCRIPTION
- telegraf descriptor adjusted so it can read more than one config file
- elasticsearch can add config into telegraf - I added SOME configuration that did not break telegraf. It needs to be finished in order to collect the data as we desire. 

- [ ] make telegraf config of elasticsearch input more beautiful