### PR TITLE
More failsafe userinfo resolution for Grafana

### DIFF
--- a/Site/ASAB Maestro/Descriptors/grafana.yaml
+++ b/Site/ASAB Maestro/Descriptors/grafana.yaml
@@ -35,8 +35,9 @@ descriptor:
     GF_AUTH_GENERIC_OAUTH_API_URL: "{{SEACAT_AUTH_PUBLIC}}/openidconnect/userinfo"
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
     GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(resources."*"[*], 'authz:superuser') && 'Admin' || contains(resources."*"[*], 'tools:grafana:edit') && 'Editor' || contains(resources."*"[*], 'tools:grafana:access') && 'Viewer'
-    GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH: preferred_username
-    GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH: preferred_username
+    GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH: preferred_username || username || sub
+    GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH: preferred_username || username || sub
+    GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH: email || sub
     GF_AUTH_SIGNOUT_REDIRECT_URL: "{{PUBLIC_URL}}"
 
 files:


### PR DESCRIPTION
This fixes login to grafana for users without email address by adding fallback to the subject (sub) userinfo field.