### PR TITLE
InfluxDB - default retention policy

### DIFF
--- a/Site/ASAB Maestro/Descriptors/influxdb.yaml
+++ b/Site/ASAB Maestro/Descriptors/influxdb.yaml
@@ -27,6 +27,7 @@ descriptor:
     DOCKER_INFLUXDB_INIT_ORG: "{{INFLUXDB_ORG}}" # set by the Remote Control
     DOCKER_INFLUXDB_INIT_BUCKET: "{{INFLUXDB_BUCKET}}"  # set by the Remote Control
     DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: '{{INFLUXDB_TOKEN}}'
+    DOCKER_INFLUXDB_INIT_RETENTION: 180d
 
 nginx:
   upstreams:


### PR DESCRIPTION
closes #21 

180 days retention

it is INIT retention - that means that only new installations and buckets will be affected by this retention setting

![image](https://github.com/TeskaLabs/asab-maestro-library/assets/82450969/7025b705-044d-4024-99cb-8aaa26401a63)
