### PR TITLE
asab-iris: add markdown wrapper configuration

### DIFF
--- a/Site/ASAB Maestro/Descriptors/asab-iris.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-iris.yaml
@@ -19,6 +19,8 @@ asab:
     # [smtp] must be filled from general confguration (user)
     # [slack] must be filled from general confguration (user)
     # [variables] must be filled from general confguration (user)
+  email:
+    markdown_wrapper: /Templates/Wrapper/markdown_wrapper.html
 
 asab-config:
   asab-iris:

--- a/Site/ASAB Maestro/Descriptors/asab-iris.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-iris.yaml
@@ -20,7 +20,7 @@ asab:
     # [slack] must be filled from general confguration (user)
     # [variables] must be filled from general confguration (user)
   email:
-    markdown_wrapper: /Templates/Wrapper/markdown_wrapper.html
+    markdown_wrapper: /Templates/Wrapper/Markdown Wrapper.html
 
 asab-config:
   asab-iris:


### PR DESCRIPTION
I think I was told to put this configuration to the descriptor. It is slightly weird here and I don't know what happens if the file does not exist. Let's see...