### PR TITLE
Mongo sherpas refactoring

### DIFF
--- a/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
+++ b/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
@@ -38,8 +38,11 @@ function main() {
 				print("Failed with " + error.name + ": " + error.message)
 				continue;
 			}
-
+			
+			// db.hello() returns an object with basic data about the mongo instance and the database
+			// https://www.mongodb.com/docs/manual/reference/command/hello/#mongodb-dbcommand-dbcmd.hello
 			const hello = db.hello()
+
 			// To setup replicaset, the replicaset needs to be both in configuration but also initialized. However, it has to be initialized only once. 
 			// https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set/#initiate-the-replica-set
 			// Mongo starts with rs0 configuration and the replicaset has not yet been initialized. However, this state cannot be tested anyhow.

--- a/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
+++ b/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
@@ -1,27 +1,17 @@
 const fs = require("fs")
 
-
 /**
  * The function reconfigureReplicaSet is used to find the primary node in a replica set and apply a new configuration to it.
  */
 function reconfigureReplicaSet() {
 	const newConfig = JSON.parse(fs.readFileSync('/script/replica-set.json', 'utf8'))
-	try {
-		// If there is a configuration, the replica set has been initialized and it want's to be reconfigured, which can be done only from the primary node
-		let currentConfig = rs.conf();
-		newConfig.version = newConfig.version + 1;
-		rs.reconfig(newConfig, { force: false });
-		print("SUCCESS_RECONFIG");
-	} catch (error) {
-		// If there is no replica set configuration, it is probably a first node in the cluster and the replica set should be initialized
-		if (error.codeName === 'NotYetInitialized' || error.codeName === 'InvalidReplicaSetConfig') {
-			rs.initiate(newConfig);
-			print("SUCCESS_INITIATE");
-		} else {
-			print("Failed with " + error.name + ": " + error.message + " / " + error.codeName);
-			throw new Error("ERROR_RECONFIG");
-		}
-	}
+	newConfig.version = newConfig.version + 1;
+	rs.reconfig(newConfig, { force: false });
+}
+
+function initiateReplicaSet() {
+	const newConfig = JSON.parse(fs.readFileSync('/script/replica-set.json', 'utf8'))
+	rs.initiate(newConfig);
 }
 
 /**
@@ -49,28 +39,47 @@ function main() {
 				continue;
 			}
 
-			if (!db.isMaster()) {
-				print("Not a master, continuing to the next Mongo node.");
+			const hello = db.hello()
+			// To setup replicaset, the replicaset needs to be both in configuration but also initialized. However, it has to be initialized only once. 
+			// https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set/#initiate-the-replica-set
+			// Mongo starts with rs0 configuration and the replicaset has not yet been initialized. However, this state cannot be tested anyhow.
+			// In this state the mongo instance is not primary, it is not secondary, it has replicaset, and the only indicative thing is this message: 'Does not have a valid replica set config'
+
+			if (!hello.isWritablePrimary && !hello.secondary && hello.isreplicaset && hello.info === 'Does not have a valid replica set config') {
+				// replicaset has not yet been initialized
+				try {
+					initiateReplicaSet()
+					print("Initialization successful.")
+					print("SUCCESS!");
+					quit(0);
+
+				} catch (e) {
+					print("Initialization of replicaset failed.")
+					print("Exiting due to failure.")
+					quit(1);
+				}
+			}
+
+			if (!hello.isWritablePrimary) {
+				print("Not a primary, continuing to the next Mongo node.");
 				continue;
 			};
 		
-			print("This is a master, reconfiguring a replica set.");
+			print("This is a primary, reconfiguring a replicaset.");
 
 			try {
 				reconfigureReplicaSet();
+				print("Successfully reconfigured replicaset.");
+				print("SUCCESS!");
+				quit(0);
 			} catch (e) {
-				print("Failed to reconfigure replica set with " + error.name + ": " + error.message)
-				break;
+				print("Reconfiguration failed with " + e.name + ": " + e.message + " / " + error.codeName);
+				print("Exiting due to failure.")
+				quit(1);
 			}
-
-			print("SUCCESS!");
-			quit(0);  // SUCCESS!
 		};
 		sleep(5000);
 	}
-
-	print("Exiting due to failure.")
-	quit(1);
 };
 
 main();

--- a/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
+++ b/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
@@ -35,36 +35,23 @@ function transform_collection(collectionName, data) {
 		record["_c"] = new Date()
 		record["_m"] = new Date()
 		record["_v"] = 1
+		record["managed_by"] = "maestro"
 	});
 
 	return data
 }
 
-/**
- * The function upsertSeaCatAuthCollections inserts or updates multiple collections in the "auth"
- * database using the provided data, and handles duplicate key errors.
- * @param data - The `data` parameter is an object that contains collections and their corresponding
- * data to be upserted into the "auth" database. Each key in the `data` object represents a collection
- * name, and the corresponding value is an array of documents to be inserted or updated in that
- * collection.
- */
-function insertSeaCatAuthCollections(data) {
+
+function upsertSeaCatAuthCollections(data) {
 	// seacat auth uses "auth" database
 	authDb = db.getSiblingDB( "auth" );
 	data.forEach(line => {
 		let collectionName = line[0]
 		const collection = authDb.getCollection(collectionName)
-		try {
-			res = collection.insertMany(line[1], {ordered: false})
-			print(`Insterted ${Object.keys(res.insertedIds).length} into ${collectionName} collection.`)
-		} catch (MongoBulkWriteError) {
-			if (MongoBulkWriteError.code === 11000) {
-				res = MongoBulkWriteError.result
-				print(`Insterted ${res.insertedCount} into ${collectionName} collection.`)
-			} else {
-				throw MongoBulkWriteError
-			}
-		}
+		line[1].forEach(document => {
+			print(document["_id"])
+			collection.updateOne({_id: document["_id"]}, { $set: document }, {upsert: true})
+		});
 	});
 }
 
@@ -92,7 +79,8 @@ function main() {
 				continue
 			}
 
-			if (!db.isMaster()?.isWritablePrimary ?? false) {  //The optional chaining operator (?.) will return undefined instead of causing an error if isMaster() returns null or undefined, or if isWritablePrimary does not exist on the object returned by isMaster(). The nullish coalescing operator (??) will return the value on its right-hand side if the value on its left-hand side is null or undefined.
+			if (!db.hello()?.isWritablePrimary ?? false) {  //The optional chaining operator (?.) will return undefined instead of causing an error if isMaster() returns null or undefined, or if isWritablePrimary does not exist on the object returned by isMaster(). The nullish coalescing operator (??) will return the value on its right-hand side if the value on its left-hand side is null or undefined.
+				// skip mongo instances that are not primary
 				continue
 			};
 		
@@ -105,7 +93,7 @@ function main() {
 			
 	
 			try {
-				insertSeaCatAuthCollections(data);
+				upsertSeaCatAuthCollections(data);
 			} catch (err) {
 				print("UNSUCCESSFUL_DATA_INSERT", err);
 				quit(1)

--- a/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
+++ b/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
@@ -35,7 +35,7 @@ function transform_collection(collectionName, data) {
 		record["_c"] = new Date()
 		record["_m"] = new Date()
 		record["_v"] = 1
-		record["managed_by"] = "maestro"
+		record["managed_by"] = "asab-maestro"
 	});
 
 	return data

--- a/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
+++ b/Site/ASAB Maestro/Files/seacat-auth/script/mongo-insert.js
@@ -79,6 +79,8 @@ function main() {
 				continue
 			}
 
+			// db.hello() returns an object with basic data about the mongo instance and the database
+			// https://www.mongodb.com/docs/manual/reference/command/hello/#mongodb-dbcommand-dbcmd.hello
 			if (!db.hello()?.isWritablePrimary ?? false) {  //The optional chaining operator (?.) will return undefined instead of causing an error if isMaster() returns null or undefined, or if isWritablePrimary does not exist on the object returned by isMaster(). The nullish coalescing operator (??) will return the value on its right-hand side if the value on its left-hand side is null or undefined.
 				// skip mongo instances that are not primary
 				continue


### PR DESCRIPTION
## mongo init
I think it worked before only by accident. I improved the way how to decide when to initiate replicaset and when to reconfigure it. Unfortunately, there is no specific check for a mongo instance that is configured to be used in replicaset, but the replicaset has not yet been initiated. In mongo docs, I am advised to initiate the replicaset **only once** but there is no hint how to ensure it. 

## seacat auth sherpa
I changed the logic **from insert to upsert**. It means that all changes in library get propagated everywhere and it also means pieces from library are **managed** by maestro. @byewokko fyi (is "managed_by" = "maestro" ok?)