### PR TITLE
Mongo: Disable sending telemetry to mongo server

### DIFF
--- a/Site/ASAB Maestro/Descriptors/mongo.yaml
+++ b/Site/ASAB Maestro/Descriptors/mongo.yaml
@@ -40,5 +40,13 @@ files:
         port: 27017
       replication:
         replSetName: rs0
+
+  # Disable telemetry collection by MongoDB
+  - "conf/mongosh.conf": |
+      enableTelemetry: false
+
+  - "conf/mongosync.conf": |
+      disableTelemetry: true
+
   - "script/mongo-init.js"
   # - "script/replica-set.json" will be added by ASAB Remote Control / Mongo Tech

--- a/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
+++ b/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
@@ -71,6 +71,7 @@ function main() {
 			print("This is a primary, reconfiguring a replicaset.");
 
 			try {
+				disableTelemetry()
 				reconfigureReplicaSet();
 				print("Successfully reconfigured replicaset.");
 				print("SUCCESS!");

--- a/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
+++ b/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
@@ -71,7 +71,7 @@ function main() {
 			print("This is a primary, reconfiguring a replicaset.");
 
 			try {
-				disableTelemetry()
+				db.disableTelemetry()  // Disable collectoíon of usage data by MongoDB
 				reconfigureReplicaSet();
 				print("Successfully reconfigured replicaset.");
 				print("SUCCESS!");

--- a/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
+++ b/Site/ASAB Maestro/Files/mongo/script/mongo-init.js
@@ -71,7 +71,6 @@ function main() {
 			print("This is a primary, reconfiguring a replicaset.");
 
 			try {
-				db.disableTelemetry()  // Disable collectoíon of usage data by MongoDB
 				reconfigureReplicaSet();
 				print("Successfully reconfigured replicaset.");
 				print("SUCCESS!");


### PR DESCRIPTION
Before:
```
root@lmio-eliska-1:/opt/site# ./gov.sh compose up mongo-1-init
[+] Running 2/0
 ✔ Container mongo-1       Running                                                                                                                                                                              0.0s 
 ✔ Container mongo-1-init  Created                                                                                                                                                                              0.0s 
Attaching to mongo-1-init
mongo-1-init  | Current Mongosh Log ID:	66604bf83ead6d0504baddb3
mongo-1-init  | Using Mongosh:		1.10.6
mongo-1-init  | 
mongo-1-init  | For mongosh info see: https://docs.mongodb.com/mongodb-shell/
mongo-1-init  | 
mongo-1-init  | 
mongo-1-init  | To help improve our products, anonymous usage data is collected and sent to MongoDB periodically (https://www.mongodb.com/legal/privacy-policy).
mongo-1-init  | You can opt-out by running the disableTelemetry() command.
mongo-1-init  | 
mongo-1-init  | Loading file: /script/mongo-init.js
mongo-1-init  | (Re)-initializing the Mongo cluster.
mongo-1-init  | Connection attempt 1
mongo-1-init  | Connecting to  mongo-1:27017
mongo-1-init  | This is a primary, reconfiguring a replicaset.
mongo-1-init  | Successfully reconfigured replicaset.
mongo-1-init  | SUCCESS!
mongo-1-init exited with code 0
```

After:
```
root@lmio-eliska-1:/opt/site# ./gov.sh compose up mongo-1-init
[+] Running 2/1
 ✔ Container mongo-1       Recreated                                                                                                                                                                            0.8s 
 ✔ Container mongo-1-init  Recreated                                                                                                                                                                            0.0s 
Attaching to mongo-1-init
mongo-1-init  | Current Mongosh Log ID:	6660b5952d32e0db754c86b5
mongo-1-init  | Using Mongosh:		1.10.6
mongo-1-init  | 
mongo-1-init  | For mongosh info see: https://docs.mongodb.com/mongodb-shell/
mongo-1-init  | 
mongo-1-init  | Loading file: /script/mongo-init.js
mongo-1-init  | (Re)-initializing the Mongo cluster.
mongo-1-init  | Connection attempt 1
mongo-1-init  | Connecting to  mongo-1:27017
mongo-1-init  | Failed with MongoNetworkError: connect ECONNREFUSED 10.173.34.137:27017
mongo-1-init  | Connection attempt 2
mongo-1-init  | Connecting to  mongo-1:27017
mongo-1-init  | This is a primary, reconfiguring a replicaset.
mongo-1-init  | ReferenceError: error is not defined
mongo-1-init exited with code 1
```
But there's an error :( some other error :(