### PR TITLE
Config sherpa: retry in any case

### DIFF
--- a/Site/ASAB Maestro/Files/asab-config/content/script.py
+++ b/Site/ASAB Maestro/Files/asab-config/content/script.py
@@ -69,12 +69,17 @@ async def main():
 						res += await upload_config(session, node_id, config_type, config_file_name, config_file_data)
 
 				if res > 0:
-					sys.exit(1)
-			sys.exit(0)
+					print("Upload of configuration failed. Retrying in 5 seconds...")
+					time.sleep(5)
+				else:
+					sys.exit(0)  # SUCCESS!
 		except aiohttp.client_exceptions.ClientConnectorError:
 			print("Cannot reach asab-config. Retrying in 5 seconds...")
 			time.sleep(5)
 		i -= 1
+
+	print("Upload of configuration failed.")
+	sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/Site/ASAB Maestro/Files/asab-config/content/script.py
+++ b/Site/ASAB Maestro/Files/asab-config/content/script.py
@@ -53,7 +53,7 @@ async def main():
 		print("Error decoding JSON data from /content/content.json file")
 		return
 	
-	i = 5
+	i = 10
 	while i > 0:
 		try:
 			# Initialize aiohttp session and send requests
@@ -69,13 +69,13 @@ async def main():
 						res += await upload_config(session, node_id, config_type, config_file_name, config_file_data)
 
 				if res > 0:
-					print("Upload of configuration failed. Retrying in 5 seconds...")
-					time.sleep(5)
+					print("Upload of configuration failed. Retrying in 10 seconds...")
+					time.sleep(10)
 				else:
 					sys.exit(0)  # SUCCESS!
 		except aiohttp.client_exceptions.ClientConnectorError:
-			print("Cannot reach asab-config. Retrying in 5 seconds...")
-			time.sleep(5)
+			print("Cannot reach asab-config. Retrying in 10 seconds...")
+			time.sleep(10)
 		i -= 1
 
 	print("Upload of configuration failed.")


### PR DESCRIPTION
It is common, that asab-config is up and running but zookeeper container is not yet ready, so we want to wait for that as well

```
root@lmio-eliska-1:/opt/site# ./gov.sh compose up asab-config-1-content
[+] Running 2/0
 ✔ Container asab-config-1          Running                                                                                                                                                                     0.0s 
 ✔ Container asab-config-1-content  Created                                                                                                                                                                     0.0s 
Attaching to asab-config-1-content
asab-config-1-content  | Upload of config type 'Tools' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Tools'}}
asab-config-1-content  | Upload of config 'Tools/Zoonavigator' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Tools', 'config_name': 'Zoonavigator.json'}}
asab-config-1-content  | Upload of config 'Tools/Grafana' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Tools', 'config_name': 'Grafana.json'}}
asab-config-1-content  | Upload of config 'Tools/Kafdrop' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Tools', 'config_name': 'Kafdrop.json'}}
asab-config-1-content  | Upload of config type 'Tenants' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Tenants'}}
asab-config-1-content  | Upload of config 'Tenants/system' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Tenants', 'config_name': 'system.json'}}
asab-config-1-content  | Upload of config type 'Discover' was not successful. Status: 400. Reason: {'result': 'FAILED', 'error': {'message': 'Connection to ZooKeeper lost. Action could not be proceeed.', 'error_code': 'ErrorCode.ZOOKEEPER_LOST', 'config_type': 'Discover'}}
asab-config-1-content  | Upload of configuration failed. Retrying in 5 seconds...
asab-config-1-content  | Config type 'Tools' uploaded to asab-config
asab-config-1-content  | Config 'Zoonavigator' of type 'Tools' uploaded to asab-config
asab-config-1-content  | Config 'Grafana' of type 'Tools' uploaded to asab-config
asab-config-1-content  | Config 'Kafdrop' of type 'Tools' uploaded to asab-config
asab-config-1-content  | Config type 'Tenants' uploaded to asab-config
asab-config-1-content  | Config 'system' of type 'Tenants' uploaded to asab-config
asab-config-1-content  | Config type 'Discover' uploaded to asab-config
asab-config-1-content exited with code 0
```