### PR TITLE
Feature/influxdb non admin token

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,8 @@ Azure master:
   only:
     - main
   script:
-    - apk update
-    - apk add xz
+    - yum update -y
+    - yum install tar xz -y
     - tar cf /tmp/asab-maestro-library.tar --exclude='.git'  --exclude='./.git' --exclude='./.gitignore' --exclude='./.gitlab-ci.yml' --exclude='./README.md' --exclude='./CHANGELOG' --exclude='./CONTRIBUTING.md' --exclude='./LICENSE' .
     - xz -9 -e -T 0 /tmp/asab-maestro-library.tar
     - mv /tmp/asab-maestro-library.tar.xz asab-maestro-library.tar.xz
@@ -35,8 +35,8 @@ Azure branch:
     - production
     - main
   script:
-    - apk update
-    - apk add xz
+    - yum update -y
+    - yum install tar xz -y
     - echo ${CI_COMMIT_BRANCH}
 
     - tar cf /tmp/asab-maestro-library.tar --exclude='.git'  --exclude='./.git' --exclude='./.gitignore' --exclude='./.gitlab-ci.yml' --exclude='./README.md' --exclude='./CHANGELOG' --exclude='./CONTRIBUTING.md' --exclude='./LICENSE' .
@@ -68,8 +68,8 @@ Azure tag:
     - branches
 
   script:
-    - apk update
-    - apk add xz
+    - yum update -y
+    - yum install tar xz -y
     - echo ${CI_COMMIT_REF_NAME}
     - tar cf /tmp/asab-maestro-library.tar --exclude='.git'  --exclude='./.git' --exclude='./.gitignore' --exclude='./.gitlab-ci.yml' --exclude='./README.md' --exclude='./CHANGELOG' --exclude='./CONTRIBUTING.md' --exclude='./LICENSE' .
     - xz -9 -e -T 0 /tmp/asab-maestro-library.tar

--- a/Site/ASAB Maestro/Descriptors/influxdb.yaml
+++ b/Site/ASAB Maestro/Descriptors/influxdb.yaml
@@ -40,6 +40,23 @@ nginx:
       - rewrite ^/influxdb/(.*) /$1 break
       - proxy_pass http://upstream-influxdb
 
+sherpas:
+  # Sherpas containers: akin to their namesake mountain guides, these containers provide essential support and guidance throughout the application's lifecycle.
+  # provide a name to your sherpa and a descriptor for its very own container.
+  init:
+    image: infuxdb:{{ VERSIONS["influxdb"] }}
+    entrypoint: ["bash", "/script/influx-init.sh"]
+    command: ["echo", "DONE"]
+    volumes:
+    - "{{SITE}}/{{INSTANCE_ID}}/script:/script:ro"
+    depends_on: ["{{INSTANCE_ID}}"]
+    environment:
+      MONGO_HOSTNAMES: "{{MONGO_HOSTNAMES}}"
+
+files:
+  - "script/influx-init.sh"
+  # - "script/replica-set.json" will be added by ASAB Remote Control / Mongo Tech
+
   # Exposure of InfluxDB on the public HTTPS is disabled b/c there is no authorization introspection available
   # https:
   #    location /influxdb:

--- a/Site/ASAB Maestro/Descriptors/influxdb.yaml
+++ b/Site/ASAB Maestro/Descriptors/influxdb.yaml
@@ -51,7 +51,10 @@ sherpas:
     - "{{SITE}}/{{INSTANCE_ID}}/script:/script:ro"
     depends_on: ["{{INSTANCE_ID}}"]
     environment:
-      MONGO_HOSTNAMES: "{{MONGO_HOSTNAMES}}"
+      INFLUXDB_HOSTNAME: "{{INFLUXDB_HOSTNAME}}"
+      DOCKER_INFLUXDB_INIT_BUCKET: "{{DOCKER_INFLUXDB_INIT_BUCKET}}"
+      DOCKER_INFLUXDB_INIT_ORG: "{{DOCKER_INFLUXDB_INIT_ORG}}"
+      DOCKER_INFLUXDB_INIT_USERNAME: "{{DOCKER_INFLUXDB_INIT_USERNAME}}"
 
 files:
   - "script/influx-init.sh"

--- a/Site/ASAB Maestro/Files/influxdb/influx-init.sh
+++ b/Site/ASAB Maestro/Files/influxdb/influx-init.sh
@@ -1,21 +1,21 @@
 #!/bin/sh
 
 # Wait for InfluxDB to start
-until curl -s http://{{INFLUXDB_URL}}:8086/health | grep -q '"status": "pass"'; do
+until curl -s http://{{INFLUXDB_HOSTNAME}}:8086/health | grep -q '"status": "pass"'; do
   echo "Waiting for InfluxDB to start..."
   sleep 1
 done
 
 # Get the bucket ID
-BUCKET_ID=$(curl -s -X GET http://{{INFLUXDB_URL}}:8086/api/v2/buckets -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.buckets[] | select(.name=="{{BUCKET_NAME}}") | .id')
+BUCKET_ID=$(curl -s -X GET http://{{INFLUXDB_HOSTNAME}}:8086/api/v2/buckets -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.buckets[] | select(.name=="{{DOCKER_INFLUXDB_INIT_BUCKET}}") | .id')
 # Get the org ID
-ORG_ID=$(curl -s -X GET http://{{INFLUXDB_URL}}:8086/api/v2/orgs -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.orgs[] | select(.name=="{{ORG_NAME}}") | .id')
+ORG_ID=$(curl -s -X GET http://{{INFLUXDB_HOSTNAME}}:8086/api/v2/orgs -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.orgs[] | select(.name=="{{DOCKER_INFLUXDB_INIT_ORG}}") | .id')
 
 # Get the user ID
-USER_ID=$(curl -s -X GET http://{{INFLUXDB_URL}}:8086/api/v2/users -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.users[] | select(.name=="{{USER_NAME}}") | .id')
+USER_ID=$(curl -s -X GET http://{{INFLUXDB_HOSTNAME}}:8086/api/v2/users -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.users[] | select(.name=="{{DOCKER_INFLUXDB_INIT_USERNAME}}") | .id')
 
 # Create the non-admin token using the InfluxDB API v2
-curl -X POST http://{{INFLUXDB_URL}}:8086/api/v2/authorizations \
+curl -X POST http://{{INFLUXDB_HOSTNAME}}:8086/api/v2/authorizations \
   -H "Authorization: Token {{INFLUXDB_TOKEN}}" \
   -H "Accept: application/json" \
   -H "Content-Type: application/json" \

--- a/Site/ASAB Maestro/Files/influxdb/influx-init.sh
+++ b/Site/ASAB Maestro/Files/influxdb/influx-init.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Wait for InfluxDB to start
+until curl -s http://{{INFLUXDB_URL}}:8086/health | grep -q '"status": "pass"'; do
+  echo "Waiting for InfluxDB to start..."
+  sleep 1
+done
+
+# Get the bucket ID
+BUCKET_ID=$(curl -s -X GET http://{{INFLUXDB_URL}}:8086/api/v2/buckets -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.buckets[] | select(.name=="{{BUCKET_NAME}}") | .id')
+# Get the org ID
+ORG_ID=$(curl -s -X GET http://{{INFLUXDB_URL}}:8086/api/v2/orgs -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.orgs[] | select(.name=="{{ORG_NAME}}") | .id')
+
+# Get the user ID
+USER_ID=$(curl -s -X GET http://{{INFLUXDB_URL}}:8086/api/v2/users -H 'Authorization: Token "{{INFLUXDB_TOKEN}}"' -H "Accept: application/json" | jq -r '.users[] | select(.name=="{{USER_NAME}}") | .id')
+
+# Create the non-admin token using the InfluxDB API v2
+curl -X POST http://{{INFLUXDB_URL}}:8086/api/v2/authorizations \
+  -H "Authorization: Token {{INFLUXDB_TOKEN}}" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "description": "Non-admin user with write access",
+        "orgID": "'"$ORG_ID"'", 
+        "permissions": [
+          {
+            "action": "write",
+            "resource": {
+              "type": "buckets",
+              "id": "'"$BUCKET_ID"'"
+            }
+          }
+        ],
+        "status": "active",
+        "userID": "'"$USER_ID"'" 
+      }'


### PR DESCRIPTION
This is about generating a non admin token for the services to use. I am kind of lost what variables I can use, but I think I may have found them (needs to be checked). Also, there is one thing remaining, how do I pass on the generated token to be used. The output of the script looks like this:
{
   "id":"0dd2e35923eb7000",
   "token":"t4ZRXhJqhNoqA0R7Z6Fz5X_tkvgzEXfreoZUpMwp801M31b31M7xg10tYpmD1CDO4pZuWxR9b3G0p_BpMSMy5Q==",
   "status":"active",
   "description":"Non-admin user with write access",
   "orgID":"29ecabe6fff1d77b",
   "org":"myorg",
   "userID":"0dd2e0e2c641d000",
   "user":"myuser",
   "permissions":[
      {
         "action":"write",
         "resource":{
            "type":"buckets",
            "id":"890ceddae8caa7af",
            "name":"mybucket"
         }
      }
   ],
   "links":{
      "self":"/api/v2/authorizations/0dd2e35923eb7000",
      "user":"/api/v2/users/0dd2e0e2c641d000"
   },
   "createdAt":"2024-10-17T17:39:18.799029086Z",
   "updatedAt":"2024-10-17T17:39:18.799029086Z"
}
I will neet to extract the token somehow.