### PR TITLE
Jupyter cannot isolate tenants

### DIFF
--- a/Site/ASAB Maestro/Descriptors/jupyter.yaml
+++ b/Site/ASAB Maestro/Descriptors/jupyter.yaml
@@ -70,10 +70,13 @@ asab-config:
                   "image": "media/tools/jupyter.svg",
                   "name": "Jupyter Notebook",
                   "url": "/jupyter"
+              },
+              "Authorization": {
+                  "tenants": "system"
               }
           }
 
-        if_not_exists: true
+        if_not_exists: false
 
 
 nginx:


### PR DESCRIPTION
Jupyter does not come with auth. It does not isolate tenants. If someone decides to export data to jupyter, any other user can see it. 
I'd consider dropping this feature from LMIO entirely. At least from default LMIO installation and definitely from multi-tenant LMIO. I've never seen anyone using it anyway.