### PR TITLE
All required items must have at least 1 character

### DIFF
--- a/Site/ASAB Maestro/Descriptors/asab-iris.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-iris.yaml
@@ -37,11 +37,13 @@ asab-config:
               "properties": {
                 "token": {
                   "type": "string",
-                  "title": "Token"
+                  "title": "Token",
+                  "minLength": 1
                   },
                 "channel": {
                   "type": "string",
-                  "title": "Channel"
+                  "title": "Channel",
+                  "minLength": 1
                   }
               },
               "required": ["token", "channel"]
@@ -54,7 +56,8 @@ asab-config:
                 "webhook_url": {
                   "title": "Webhook URL",
                   "type": "string",
-                  "format": "uri"
+                  "format": "uri",
+                  "minLength": 1
                   }
               },
               "required": ["webhook_url"]

--- a/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
+++ b/Site/ASAB Maestro/Descriptors/seacat-auth.yaml
@@ -112,7 +112,8 @@ asab-config:
                   "default": "",
                   "examples": [
                     "Europe/Prague"
-                  ]
+                  ],
+                  "minLength": 1
                 }
               }
             }

--- a/Site/ASAB Maestro/Files/asab-remote-control/asab-config/SMTP/__schema__.json
+++ b/Site/ASAB Maestro/Files/asab-remote-control/asab-config/SMTP/__schema__.json
@@ -14,7 +14,8 @@
 					"type": "string",
 					"title": "Host",
 					"description": "Specify the domain name or IP address of your SMTP server.",
-					"examples": "smtp.example.com"
+					"examples": "smtp.example.com",
+					"minLength": 1
 				},
 				"port": {
 					"type": "integer",

--- a/Site/ASAB Maestro/Files/nginx/asab-config/Tools/__schema__.json
+++ b/Site/ASAB Maestro/Files/nginx/asab-config/Tools/__schema__.json
@@ -40,7 +40,8 @@
 					"default": "",
 					"examples": [
 						"MyTool"
-					]
+					],
+					"minLength": 1
 				},
 				"url": {
 					"type": "string",
@@ -49,7 +50,8 @@
 					"default": "",
 					"examples": [
 						"https://logman.io/my-tool"
-					]
+					],
+					"minLength": 1
 				},
 				"image": {
 					"type": "string",
@@ -63,7 +65,8 @@
 					},
 					"examples": [
 						"tools/my-tool.svg"
-					]
+					],
+					"minLength": 1
 				}
 			}
 		},


### PR DESCRIPTION
UI sends empty strings for empty values in the formular.
JSON schema works with empty strings as valid string.
That means that if a user does not fill in the value in the UI, empty string is sent and the validation goes green even though the required value was not filled in by the user.

I have made changes in the ASAB Config code: If field is NOT required and it is empty string, it is removed before validation.

(I cannot remove required fileds. That is not right.)

However, that leaves required fields that are empty strings still passing through the validation.
Thus, I introduced one more condition in the schema (in all the config schemas) - if the string is required, it must be at least 1 character long - that means it cannot be empty string.

I would like to ask mainly Mithun and other colleagues that "own" the respective json schemas to check, test and validate that this condition is right in all cases.
