### PR TITLE
Fix webapps sherpa: curl failing due to ssl error

### DIFF
--- a/Site/ASAB Maestro/Files/nginx/sherpa/webapp-dist.sh
+++ b/Site/ASAB Maestro/Files/nginx/sherpa/webapp-dist.sh
@@ -18,7 +18,7 @@ install_mfe() {  # args: URL: $1, Name: $2
 	rm -rf "$2.new" "$CACHE_DIR/$2.etag-new"
 	
 	# Download the web application from the provided URL
-	curl --silent --show-error \
+	curl -k --silent --show-error \
 		--etag-save "$CACHE_DIR/$2.etag-new" \
 		--etag-compare "$CACHE_DIR/$2.etag" \
 		--max-filesize ${MAXSIZE} \
@@ -60,7 +60,7 @@ install_spa() {  # args: URL: $1, Name: $2
 	rm -rf "$2.new" "$CACHE_DIR/$2.etag-new"
 	
 	# Download the web application from the provided URL
-	curl --silent --show-error \
+	curl -k --silent --show-error \
 		--etag-save "$CACHE_DIR/$2.etag-new" \
 		--etag-compare "$CACHE_DIR/$2.etag" \
 		--max-filesize ${MAXSIZE} \


### PR DESCRIPTION
This issue occured in only one deployment. I can't understand why it works in all the others.

```
curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
Installing lmio_webui (mfe) ...
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html
```