### PR TITLE
Elasticsearch: Allow es to autocreate indices only for self monitoring

### DIFF
--- a/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
+++ b/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
@@ -38,6 +38,7 @@ descriptor:
     xpack.security.transport.ssl.certificate_authorities: certs/ca.pem
     xpack.security.transport.ssl.certificate: certs/certificate.pem
     xpack.security.transport.ssl.key: certs/key.pem
+    action.auto_create_index: .monitoring*
 
 
 nginx:


### PR DESCRIPTION
Tested on fusion (before it went down)

Tested on lmio-eel in new fresh single node installation. Tested with system tenant only. Data is OK in LMIO Discover, monitoring in Kibana is OK (I use only stack monitoring, index management and dev tools). 

Chatgpt recommended to allow more system indices (starting with dot). I didn't find any troubles with this simple settings, though.
```
✅ Doporučené vzory pro auto_create_index

Tyto vzory pokrývají běžné případy:

.apm-*, 
.kibana_*, 
.kibana-event-log-*, 
.logs-*, 
.metrics-*, 
.monitoring-*, 
.security-*, 
.ml-*, 
.fleet-*, 
.elastic-agent*, 
synthetics-*, 
.traces-*,
profiling-*

Popis jednotlivých vzorů:
Vzor	Účel
.apm-*	Indexy pro APM data
.kibana_*, .kibana-event-log-*	Konfigurace, dashboardy, event log Kibany
.logs-*, .metrics-*, .traces-*	Data streamy z Elastic Agentů, Beats, Observability stacku
.monitoring-*	Monitoring Elasticsearch a Kibany
.security-*	Uživatelská data, audit logy
.ml-*	Machine Learning (např. modely, výstupy)
.fleet-*, .elastic-agent-*	Fleet management, policy, statusy agentů
synthetics-*	Synthetics monitoring (syntetické testy uptime)
profiling-*	Data pro continuous profiling (RUM, APM)
```

These were found on fusion. 
```
.apm-*,.async-search*,.kibana_*,.kibana-event-log-*,.ds-ilm*,.monitoring*,.security-*,.fleet*,.transform*
```

On lmio-eel, started with this configuration, I can see indices:
```
.apm*, .kibana*, .tasks, .security*, .ds*, .monitoring*
```