### PR TITLE
BSquery: fix path of file to upload

### DIFF
--- a/Site/ASAB Maestro/Descriptors/bs-query.yaml
+++ b/Site/ASAB Maestro/Descriptors/bs-query.yaml
@@ -26,14 +26,13 @@ asab:
 
 files:
   # BSQUERY_PASSWORD_HASHED parameter is created by bsquery tech
-  # Each file is targeted to /opt/site/seacat-auth-<instance-no>/script/to_upload/grafana/... Files in this folder are uploaded to mongo by mongo sherpa of seacat auth
-  - service://seacat-auth/script/to_upload/grafana/mc.json: |
+  - service://seacat-auth/script/to_upload/bs-query/mc.json: |
       [{
         "_id": "5f362cf58dca6ae0ad997bfc",
         "username": "bs-query",
         "__password": "{{BSQUERY_PASSWORD|argon2_hash}}"
       }]
-  - service://seacat-auth/script/to_upload/grafana/r.json: |
+  - service://seacat-auth/script/to_upload/bs-query/r.json: |
       [{
         "_id": "*/impersonator",
         "resources": [
@@ -41,13 +40,13 @@ files:
           "seacat:access"
         ]
       }]
-  - service://seacat-auth/script/to_upload/grafana/ct.json: |
+  - service://seacat-auth/script/to_upload/bs-query/ct.json: |
       [{
         "_id": "m2m:machine:5f362cf58dca6ae0ad997bfc system",
         "c": "m2m:machine:5f362cf58dca6ae0ad997bfc",
         "t": "system"
       }]
-  - service://seacat-auth/script/to_upload/grafana/cr.json: |
+  - service://seacat-auth/script/to_upload/bs-query/cr.json: |
       [{
         "_id": "m2m:machine:5f362cf58dca6ae0ad997bfc */impersonator",
         "c": "m2m:machine:5f362cf58dca6ae0ad997bfc",


### PR DESCRIPTION
copy&paste mistake

I think it did not cause any issue by chance. bsquery uploads files into different collections than grafana (cl, rs). However, if bs-query used the same collections as grafana, it would override the configuration.