### PR TITLE
The CA file is not required. 

### DIFF
--- a/Site/ASAB Maestro/Files/asab-remote-control/asab-config/Library/__schema__.json
+++ b/Site/ASAB Maestro/Files/asab-remote-control/asab-config/Library/__schema__.json
@@ -48,7 +48,6 @@
 					"type": "string",
 					"title": "Trusted CA Certificate File",
 					"description": "Trusted CA certificate for the library GIT provider.",
-					"default": "",
 					"$defs": {
 						"textarea": {
 							"type": "textarea"


### PR DESCRIPTION
If the default value is filled in the schema, it is used if the value is not filled by the user. 
However, if the value is not filled in, we want to keep it empty and ignore the configuration section entirely.