### PR TITLE
Nginx strict headers

### DIFF
--- a/Site/ASAB Maestro/Files/nginx/conf.d/server_https.conf
+++ b/Site/ASAB Maestro/Files/nginx/conf.d/server_https.conf
@@ -18,7 +18,7 @@ server {
 	add_header X-Frame-Options SAMEORIGIN;
 	add_header X-Content-Type-Options nosniff;
 	add_header Referrer-Policy origin;
-	add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; upgrade-insecure-requests;" always;
+	add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; upgrade-insecure-requests;" always;
 	add_header Permissions-Policy "geolocation=(), microphone=()";
 
 	# Enable Gzip compression, mainly for a static content serving


### PR DESCRIPTION
'unsafe-inline' now used on fusion to allow zoonavigator, grafana, etc. 
Grafana loads but it probably cannot refresh data and maybe something more. 

What about having extra server for the third party tools? is it possible?

<img width="2383" height="1010" alt="image" src="https://github.com/user-attachments/assets/390d8eae-f9b9-4370-b96d-51e9811351ad" />
