### PR TITLE
ASAB Config export with no oauth

### DIFF
--- a/Site/ASAB Maestro/Descriptors/asab-config.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-config.yaml
@@ -32,3 +32,9 @@ asab:
 
 nginx:
   api: 8894
+
+  # This is here for download endpoint with non-oauth authorization
+  https:
+    location /api/asab-config/export:
+      - rewrite /api/asab-config/(.*) /$1 break
+      - proxy_pass http://{{NODE_ID}}:8894


### PR DESCRIPTION
ASAB Config has export functionality, but nginx configuration does not reflect it. 

It is not perfect. The upstream is missing. The export endpoint does not have HA. But at least it is there!

**Once approved, I'll cherry-pick it also to v25.28 release branch.** @language-shprt FYI

The resulting configuration:
```
tladmin@fu01:/opt/site$ cat nginx-1/conf.d/server_https.d/location_asab-config-*
# GENERATED FILE!

location /api/asab-config-1 {
	auth_request /_oauth2_introspect;
	auth_request_set $authorization $upstream_http_authorization;
	proxy_set_header Authorization $authorization;
	
	rewrite ^/api/asab-config-1/(.*) /$1 break;
	proxy_pass http://fu01:8894;
	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
	proxy_http_version 1.1;
	proxy_set_header Upgrade $http_upgrade;
	proxy_set_header Connection "Upgrade";
}
# GENERATED FILE!

location /api/asab-config {
	auth_request /_oauth2_introspect;
	auth_request_set $authorization $upstream_http_authorization;
	proxy_set_header Authorization $authorization;
	
	rewrite ^/api/asab-config/(.*) /$1 break;
	proxy_pass http://upstream-asab-config-8894;
	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
	proxy_http_version 1.1;
	proxy_set_header Upgrade $http_upgrade;
	proxy_set_header Connection "Upgrade";
}
# GENERATED FILE!

location /api/asab-config/export {
	rewrite /api/asab-config/(.*) /$1 break;
	proxy_pass http://fu01:8894;
}
# GENERATED FILE!

location /api/asab-config-2 {
	auth_request /_oauth2_introspect;
	auth_request_set $authorization $upstream_http_authorization;
	proxy_set_header Authorization $authorization;
	
	rewrite ^/api/asab-config-2/(.*) /$1 break;
	proxy_pass http://fu02:8894;
	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
	proxy_http_version 1.1;
	proxy_set_header Upgrade $http_upgrade;
	proxy_set_header Connection "Upgrade";
}
# GENERATED FILE!

location /api/asab-config-3 {
	auth_request /_oauth2_introspect;
	auth_request_set $authorization $upstream_http_authorization;
	proxy_set_header Authorization $authorization;
	
	rewrite ^/api/asab-config-3/(.*) /$1 break;
	proxy_pass http://fu03:8894;
	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
	proxy_http_version 1.1;
	proxy_set_header Upgrade $http_upgrade;
	proxy_set_header Connection "Upgrade";
}

```