### PR TITLE
Telegraf - Fix deprecated option in ES config

### DIFF
--- a/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
+++ b/Site/ASAB Maestro/Descriptors/elasticsearch.yaml
@@ -111,7 +111,7 @@ files:
 telegraf: |
   [[inputs.elasticsearch]]
     servers = {{ELASTIC_HOSTS_AUTHORIZED}}
-    http_timeout = "9s"
+    timeout = "9s"
     local = false
     cluster_health = true
     cluster_health_level = "indices"


### PR DESCRIPTION
Deprecation warning:

```
2025-08-13T12:13:49Z W! DeprecationWarning: Option "http_timeout" of plugin "inputs.elasticsearch" deprecated since version 1.29.0 and will be removed in 1.35.0: use 'timeout' instead
```