### PR TITLE
ZooKeeper: Enable audit logs

### DIFF
--- a/Site/ASAB Maestro/Files/zookeeper/confro/zoo.cfg
+++ b/Site/ASAB Maestro/Files/zookeeper/confro/zoo.cfg
@@ -48,12 +48,5 @@ autopurge.snapRetainCount=10
 # Set to "0" to disable auto purge feature
 autopurge.purgeInterval=24
 
-## Metrics Providers
-#
-# TODO: Configure this for an InfluxDB
-# https://zookeeper.apache.org/doc/r3.8.0/zookeeperMonitor.html#influxdb
-# https://www.influxdata.com/influxdb-templates/zookeeper-monitor/
-#metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider
-#metricsProvider.httpHost=0.0.0.0
-#metricsProvider.httpPort=7000
-#metricsProvider.exportJvmInfo=true
+# Audit logs to monitor transactions (reads, writes, deletes)
+audit.enable=true


### PR DESCRIPTION
Audit logs every transaction performed on ZK server, i.e. read, write, delete.

We have to first observe the impact on ZK performance before merging this.