### PR TITLE
ZOOKEEPER_SERVERS changed from string to list

### DIFF
--- a/Site/ASAB Maestro/Descriptors/burrow.yaml
+++ b/Site/ASAB Maestro/Descriptors/burrow.yaml
@@ -13,7 +13,7 @@ descriptor:
 files:
   - "conf/burrow.toml": |
       [zookeeper]
-      servers=[ "{{ZOOKEEPER_SERVERS}}" ]
+      servers=[ "{{ZOOKEEPER_SERVERS | join(",")}}" ]
       timeout=6
       root-path="/burrow"
       [cluster.local]

--- a/Site/ASAB Maestro/Descriptors/kafka.yaml
+++ b/Site/ASAB Maestro/Descriptors/kafka.yaml
@@ -11,7 +11,7 @@ descriptor:
   environment:
     KAFKA_BROKER_ID: "{{INSTANCE_NO}}"  # `instance_no` must be an integer 
     KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://{{NODE_ID}}:9092"
-    KAFKA_ZOOKEEPER_CONNECT: "{{ZOOKEEPER_SERVERS}}/kafka"
+    KAFKA_ZOOKEEPER_CONNECT: '{{ ZOOKEEPER_SERVERS | join(",") }}/kafka'
 
   volumes:
       - "{{FAST_STORAGE}}/{{INSTANCE_ID}}/data:/var/lib/kafka/data"

--- a/Site/ASAB Maestro/Descriptors/zookeeper.yaml
+++ b/Site/ASAB Maestro/Descriptors/zookeeper.yaml
@@ -36,3 +36,8 @@ files:
   # The oracle.txt is set by the Zookeeper technology, it is needed for clusters with two nodes to resolve split-brain problem
   # More at https://zookeeper.apache.org/doc/r3.8.1/zookeeperOracleQuorums.html
   - confro/oracle.txt: 0
+
+
+telegraf: |
+  [[inputs.zookeeper]]
+    servers = {{ZOOKEEPER_SERVERS}}

--- a/Site/ASAB Maestro/Descriptors/zoonavigator.yaml
+++ b/Site/ASAB Maestro/Descriptors/zoonavigator.yaml
@@ -12,7 +12,7 @@ descriptor:
   environment:
     HTTP_PORT: "9001"
     CONNECTION_ZK_NAME: Local ZooKeeper
-    CONNECTION_ZK_CONN: "{{ZOOKEEPER_SERVERS}}"
+    CONNECTION_ZK_CONN: '{{ ZOOKEEPER_SERVERS | join(",") }}'
     AUTO_CONNECT_CONNECTION_ID: ZK
     BASE_HREF: /zoonavigator
 


### PR DESCRIPTION
ZOOKEEPER_SERVERS changed from string to list in the remote control to make configuration of telegraf possible and easy.

The string was not suitable for the telegraf config syntax.