### PR TITLE
Mongo: Listen on the internal network only

### DIFF
--- a/Site/ASAB Maestro/Descriptors/mongo.yaml
+++ b/Site/ASAB Maestro/Descriptors/mongo.yaml
@@ -29,7 +29,7 @@ sherpas:
 files:
   - "conf/mongod.conf": |
       net:
-        bindIp: 0.0.0.0
+        bindIp: "{{INTERNAL_NETWORK_IP}}"
         port: 27017
       replication:
         replSetName: rs0

--- a/Site/ASAB Maestro/Descriptors/mongo.yaml
+++ b/Site/ASAB Maestro/Descriptors/mongo.yaml
@@ -29,7 +29,7 @@ sherpas:
 files:
   - "conf/mongod.conf": |
       net:
-        bindIp: "{{INTERNAL_NETWORK_IP}}"
+        bindIp: "{{INTERNAL_NETWORK_IP}},127.0.0.1"
         port: 27017
       replication:
         replSetName: rs0


### PR DESCRIPTION
It works. mongo is happy. It works too much :grimacing: 

Will need to find out how to enter the container. 
```
$ docker exec -it mongo-1 mongosh
Current Mongosh Log ID:	68b5e3a8288d25f1b810ce71
Connecting to:		mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+1.10.6
MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017
```