### PR TITLE
Add 'srvr' command to ZK health-check

### DIFF
--- a/Site/ASAB Maestro/Descriptors/zookeeper.yaml
+++ b/Site/ASAB Maestro/Descriptors/zookeeper.yaml
@@ -27,7 +27,7 @@ descriptor:
     test:
     - "CMD-SHELL"
     - "echo ruok | nc 127.0.0.1 2181 || exit -1"  # response 'imok' when the server process is active
-    - "echo stat | nc 127.0.0.1 2181 | grep '^Mode: ' || exit -1"  # response contains 'Mode: leader/follower/observer' if the server joined the quorum
+    - "echo srvr | nc 127.0.0.1 2181 | grep '^Mode: ' || exit -1"  # response contains 'Mode: leader/follower/observer' if the server joined the quorum
     interval: 60s
     timeout: 10s
     retries: 5


### PR DESCRIPTION
`ruok` command is not enough to test healthiness of the ZK node.

> A response of "imok" does not necessarily indicate that the server has joined the quorum, just that the server process is active and bound to the specified client port. Use "stat" for details on state wrt quorum and client connection information.
- https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html

I suggest to add another test with `srvr` command:

```
tladmin@fu02:~$ echo srvr | nc -w 1 127.0.0.1 2181
Zookeeper version: 3.9.3-c26634f34490bb0ea7a09cc51e05ede3b4e320ee, built on 2024-10-17 23:21 UTC
Latency min/avg/max: 0/0.5133/8303
Received: 3434193
Sent: 3462693
Connections: 2
Outstanding: 0
Zxid: 0x230002ab0e
Mode: leader  <------------------ leader / follower /observer, not present if server haven't joined the quorum
Node count: 28581
Proposal sizes last/min/max: 48/36/75073
```

