### PR TITLE
Grafana - System level Overview - Add underscore to regex for node_id values filter

### DIFF
--- a/Site/ASAB Maestro/Files/grafana/provisioning/dashboards/system/system-level-overview.json
+++ b/Site/ASAB Maestro/Files/grafana/provisioning/dashboards/system/system-level-overview.json
@@ -1648,18 +1648,6 @@
                 "params": [],
                 "type": "mean"
               }
-            ],
-            [
-              {
-                "params": [
-                  "free_percent"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
             ]
           ],
           "tags": [

--- a/Site/ASAB Maestro/Files/grafana/provisioning/dashboards/system/system-level-overview.json
+++ b/Site/ASAB Maestro/Files/grafana/provisioning/dashboards/system/system-level-overview.json
@@ -1648,6 +1648,18 @@
                 "params": [],
                 "type": "mean"
               }
+            ],
+            [
+              {
+                "params": [
+                  "free_percent"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
             ]
           ],
           "tags": [
@@ -2000,7 +2012,7 @@
         "options": [],
         "query": "SHOW TAG VALUES WITH KEY = \"node_id\"",
         "refresh": 1,
-        "regex": "^[a-z0-9-]+$",
+        "regex": "^[a-z0-9-_]+$",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"


### PR DESCRIPTION
Extended regex for node_id to allow hostnames with "_".