### PR TITLE
Fix Grafana CSP and WS

### DIFF
--- a/Site/ASAB Maestro/Descriptors/grafana.yaml
+++ b/Site/ASAB Maestro/Descriptors/grafana.yaml
@@ -120,7 +120,14 @@ nginx:
   https:
     location /grafana:
     - rewrite ^/grafana/(.*) /$1 break
-    - add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; upgrade-insecure-requests;" always
+    - add_header Content-Security-Policy "default-src 'self'; worker-src 'self' blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; upgrade-insecure-requests;" always
+    - proxy_pass http://upstream-grafana
+    - proxy_set_header Host $host
+
+    location /grafana/api/live/ws:
+    - rewrite ^/grafana/(.*) /$1 break
+    - proxy_set_header Upgrade    websocket;
+    - proxy_set_header Connection upgrade;
     - proxy_pass http://upstream-grafana
     - proxy_set_header Host $host
 


### PR DESCRIPTION
# Issue
Grafana UI (seen on fusion) reports these errors:
```
Content-Security-Policy: The page’s settings blocked a worker script (worker-src) at blob:https://fu01.teskalabs.int/08dfa2b4-0557-4696-91c0-5c2a861dd685 from being executed because it violates the following directive: “script-src 'self' 'unsafe-inline' 'unsafe-eval'”
```
```
Firefox can’t establish a connection to the server at wss://fu01.teskalabs.int/grafana/api/live/ws.
```

# Solution
- Allow blob access in worker-src SCP.
- Add websocket location with necessary headers.