### PR TITLE
asab-pyppeteer: Switch to internal NGINX as a serving point

### DIFF
--- a/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
@@ -17,7 +17,7 @@ asab:
 
       # Points to the internal NGINX
       internal_url: http://nginx:8890
-      url_white_list: "http://nginx:8890"
+      url_white_list: http://nginx:8890
 
 nginx:
   api: 8895

--- a/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
+++ b/Site/ASAB Maestro/Descriptors/asab-pyppeteer.yaml
@@ -9,14 +9,15 @@ descriptor:
     # For a persistency of the configuration
     - "{{SITE}}/{{INSTANCE_ID}}/conf:/conf:ro"
 
-
 asab:
   configname: conf/asab-pyppeteer.conf
   config:
     pyppeteer:
       ignore_certificate_errors: 1
-      url_white_list: "{{PUBLIC_URL}}"
-      public_url: "{{PUBLIC_URL}}"
+
+      # Points to the internal NGINX
+      internal_url: http://nginx:8890
+      url_white_list: "http://nginx:8890"
 
 nginx:
   api: 8895


### PR DESCRIPTION
Reflecting changes introduced by http://gitlab.teskalabs.int/asab/asab-pyppeteer/-/merge_requests/41 ( Use of the internal nginx instead of public nginx ).

It is relevant only for changes introduced by the new version.

This change can be done in a "backward-compatible" manner (i.e. keep the old values in place), @eliska-n please advise.