### PR TITLE
Limit mongo to 2GB

### DIFF
--- a/Site/ASAB Maestro/Descriptors/mongo.yaml
+++ b/Site/ASAB Maestro/Descriptors/mongo.yaml
@@ -11,6 +11,9 @@ descriptor:
     - "{{SITE}}/{{INSTANCE_ID}}/conf:/etc/mongo:ro"
 
   command: mongod --config /etc/mongo/mongod.conf --directoryperdb
+  mem_limit: 2g
+  memswap_limit: 2g
+  mem_swappiness: 0
 
 sherpas:
   # Sherpas containers: akin to their namesake mountain guides, these containers provide essential support and guidance throughout the application's lifecycle.
@@ -31,9 +34,13 @@ files:
       net:
         bindIp: "{{INTERNAL_NETWORK_IP}},127.0.0.1"
         port: 27017
-        maxIncomingConnections: 120000
+        maxIncomingConnections: 5000
       replication:
         replSetName: rs0
+      storage:
+        wiredTiger:
+          engineConfig:
+            cacheSizeGB: 0.75
 
   # Disable telemetry collection by MongoDB
   - "conf/mongosh.conf": |

--- a/Site/ASAB Maestro/Descriptors/mongo.yaml
+++ b/Site/ASAB Maestro/Descriptors/mongo.yaml
@@ -37,10 +37,6 @@ files:
         maxIncomingConnections: 5000
       replication:
         replSetName: rs0
-      storage:
-        wiredTiger:
-          engineConfig:
-            cacheSizeGB: 0.75
 
   # Disable telemetry collection by MongoDB
   - "conf/mongosh.conf": |


### PR DESCRIPTION
:question: Isn't 2GB too little? 512 MB for cache?
:question: AI recommended to lower max incoming connections proportionally to the memory limit. do we need so many connections for any reason?

MongoDB computes size of the cache based on the configured docker memory limit (tested). 
The size of the cache is 512 MB out of 2 GB. 
```
max(0.5 × (2−1), 0.256) = 0.5 GB.
```