### PR TITLE
Fix zookeeper memory setup

### DIFF
--- a/Site/ASAB Maestro/Descriptors/zookeeper.yaml
+++ b/Site/ASAB Maestro/Descriptors/zookeeper.yaml
@@ -10,6 +10,9 @@ descriptor:
 
   entrypoint: ["/bin/bash", "-e", "/confro/zkstart.sh"]
   command: ["zkServer.sh", "start-foreground"]
+  mem_limit: 2g
+  memswap_limit: 2g
+  mem_swappiness: 0
 
   volumes:
       - "{{SITE}}/{{INSTANCE_ID}}/confro:/confro:ro"  # Read-only (ro) configuration from the site directory
@@ -20,8 +23,7 @@ descriptor:
 
   environment:
     ZOO_MY_ID: null  # This will be injected by cluster service
-    ZK_SERVER_HEAP: '2000'
-    JVMFLAGS: "-Xms2000m -Dzookeeper.multiAddress.enabled=true -Dlogback.configurationFile=/confro/logback.xml"
+    JVMFLAGS: "-Xms1g -Xmx1g -Dzookeeper.multiAddress.enabled=true -Dlogback.configurationFile=/confro/logback.xml"
 
   healthcheck:
     test:

--- a/Site/ASAB Maestro/Descriptors/zookeeper.yaml
+++ b/Site/ASAB Maestro/Descriptors/zookeeper.yaml
@@ -10,8 +10,8 @@ descriptor:
 
   entrypoint: ["/bin/bash", "-e", "/confro/zkstart.sh"]
   command: ["zkServer.sh", "start-foreground"]
-  mem_limit: 2g
-  memswap_limit: 2g
+  mem_limit: 4g
+  memswap_limit: 4g
   mem_swappiness: 0
 
   volumes:
@@ -23,7 +23,7 @@ descriptor:
 
   environment:
     ZOO_MY_ID: null  # This will be injected by cluster service
-    JVMFLAGS: "-Xms1g -Xmx1g -Dzookeeper.multiAddress.enabled=true -Dlogback.configurationFile=/confro/logback.xml"
+    JVMFLAGS: "-Xms2g -Xmx2g -Dzookeeper.multiAddress.enabled=true -Dlogback.configurationFile=/confro/logback.xml"
 
   healthcheck:
     test:


### PR DESCRIPTION
This is for dicussion. I think that this MR does not bring any effective changes. 
The setup is just more alligned with e.g. ES configuration. However, I don't find the previous config extremely wrong. 

Setting both Xms and Xmx to the same value avoids heap resizing at runtime. ZooKeeper is latency-sensitive; a stable, pre-allocated heap is preferable.

The official ZooKeeper image uses ZK_SERVER_HEAP to set -Xmx{N}m in zkEnv.sh.
So, using combination of Xms and ZK_SERVER_HEAP is also kind of right. In maestro, it might be easier to reconfigure ZK_SERVER_HEAP env varibale than all the JVMFLAGS. 

Setting up the JVM heap memory limit is sufficient. The docker limit is nice but probably won't bring much effect. 